### PR TITLE
294 Autogen subdomains

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -11,7 +11,7 @@ type Apps struct {
 }
 
 func (a Apps) Get(appName string) (*types.Application, error) {
-	res, err := a.Client.Do(http.MethodGet, path.Join("apps", appName), nil, nil)
+	res, err := a.Client.Do(http.MethodGet, path.Join("apps", appName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/autogen_subdomains.go
+++ b/autogen_subdomains.go
@@ -12,7 +12,7 @@ type AutogenSubdomains struct {
 
 // GET /orgs/:orgName/autogen_subdomains/:subdomainName
 func (a AutogenSubdomains) Get(subdomainName string) (*types.AutogenSubdomain, error) {
-	res, err := a.Client.Do(http.MethodGet, path.Join("autogen_subdomains", subdomainName), nil, nil)
+	res, err := a.Client.Do(http.MethodGet, path.Join("autogen_subdomains", subdomainName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (a AutogenSubdomains) Get(subdomainName string) (*types.AutogenSubdomain, e
 
 // POST /orgs/:orgName/autogen_subdomains
 func (a AutogenSubdomains) Create() (*types.AutogenSubdomain, error) {
-	res, err := a.Client.Do(http.MethodPost, path.Join("autogen_subdomains"), nil, nil)
+	res, err := a.Client.Do(http.MethodPost, path.Join("autogen_subdomains"), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (a AutogenSubdomains) Create() (*types.AutogenSubdomain, error) {
 
 // DELETE /orgs/:orgName/autogen_subdomains
 func (a AutogenSubdomains) Destroy(subdomainName string) (bool, error) {
-	res, err := a.Client.Do(http.MethodDelete, path.Join("autogen_subdomains", subdomainName), nil, nil)
+	res, err := a.Client.Do(http.MethodDelete, path.Join("autogen_subdomains", subdomainName), nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/autogen_subdomains.go
+++ b/autogen_subdomains.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"net/http"
+	"path"
+)
+
+type AutogenSubdomains struct {
+	Client *Client
+}
+
+// GET /orgs/:orgName/autogen_subdomains/:subdomainName
+func (a AutogenSubdomains) Get(subdomainName string) (*types.AutogenSubdomain, error) {
+	res, err := a.Client.Do(http.MethodGet, path.Join("autogen_subdomains", subdomainName), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var autogenSubdomain types.AutogenSubdomain
+	if err := a.Client.ReadJsonResponse(res, &autogenSubdomain); IsNotFoundError(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return &autogenSubdomain, nil
+}
+
+// POST /orgs/:orgName/autogen_subdomains
+func (a AutogenSubdomains) Create() (*types.AutogenSubdomain, error) {
+	res, err := a.Client.Do(http.MethodPost, path.Join("autogen_subdomains"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var autogenSubdomain types.AutogenSubdomain
+	if err := a.Client.ReadJsonResponse(res, &autogenSubdomain); IsNotFoundError(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return &autogenSubdomain, nil
+}
+
+// DELETE /orgs/:orgName/autogen_subdomains
+func (a AutogenSubdomains) Destroy(subdomainName string) (bool, error) {
+	res, err := a.Client.Do(http.MethodDelete, path.Join("autogen_subdomains", subdomainName), nil, nil)
+	if err != nil {
+		return false, err
+	}
+	if err := a.Client.VerifyResponse(res); IsNotFoundError(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/autogen_subdomains_delegation.go
+++ b/autogen_subdomains_delegation.go
@@ -39,7 +39,9 @@ func (d AutogenSubdomainsDelegation) Update(subdomainName string, delegation *ty
 	}
 
 	var updatedDelegation types.AutogenSubdomainDelegation
-	if err := d.Client.ReadJsonResponse(res, &updatedDelegation); err != nil {
+	if err := d.Client.ReadJsonResponse(res, &updatedDelegation); IsNotFoundError(err) {
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	}
 	return &updatedDelegation, nil

--- a/autogen_subdomains_delegation.go
+++ b/autogen_subdomains_delegation.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"net/http"
+	"path"
+)
+
+type AutogenSubdomainsDelegation struct {
+	Client *Client
+}
+
+// GET /orgs/autogen_subdomains/:subdomainName/delegation
+func (d *AutogenSubdomainsDelegation) Get(subdomainName string) (*types.AutogenSubdomainDelegation, error) {
+	res, err := d.Client.Do(http.MethodGet, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var delegation types.AutogenSubdomainDelegation
+	if err := d.Client.ReadJsonResponse(res, &delegation); IsNotFoundError(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return &delegation, nil
+}
+
+// PUT /orgs/autogen_subdomains/:subdomainId/delegation ...
+func (d *AutogenSubdomainsDelegation) UpdateAutogenSubdomainDelegation(subdomainName string, delegation *types.AutogenSubdomainDelegation) (*types.AutogenSubdomainDelegation, error) {
+	rawPayload, _ := json.Marshal(delegation)
+	req, err := d.Client.CreateRequest(http.MethodPut, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, bytes.NewReader(rawPayload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	httpClient := &http.Client{
+		Transport: d.Client.Config.CreateTransport(http.DefaultTransport),
+	}
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedDelegation types.AutogenSubdomainDelegation
+	if err := d.Client.ReadJsonResponse(res, &updatedDelegation); err != nil {
+		return nil, err
+	}
+	return &updatedDelegation, nil
+}
+
+// DELETE /orgs/autogen_subdomains/:subdomainId/delegation ...
+func (d *AutogenSubdomainsDelegation) DestroyAutogenSubdomainDelegation(subdomainName string) (found bool, err error) {
+	res, err := d.Client.Do(http.MethodDelete, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, nil)
+	if err != nil {
+		return false, err
+	}
+	if err := d.Client.VerifyResponse(res); IsNotFoundError(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/autogen_subdomains_delegation.go
+++ b/autogen_subdomains_delegation.go
@@ -14,7 +14,7 @@ type AutogenSubdomainsDelegation struct {
 
 // GET /orgs/autogen_subdomains/:subdomainName/delegation
 func (d *AutogenSubdomainsDelegation) Get(subdomainName string) (*types.AutogenSubdomainDelegation, error) {
-	res, err := d.Client.Do(http.MethodGet, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, nil)
+	res, err := d.Client.Do(http.MethodGet, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -31,16 +31,9 @@ func (d *AutogenSubdomainsDelegation) Get(subdomainName string) (*types.AutogenS
 // PUT /orgs/autogen_subdomains/:subdomainId/delegation ...
 func (d *AutogenSubdomainsDelegation) UpdateAutogenSubdomainDelegation(subdomainName string, delegation *types.AutogenSubdomainDelegation) (*types.AutogenSubdomainDelegation, error) {
 	rawPayload, _ := json.Marshal(delegation)
-	req, err := d.Client.CreateRequest(http.MethodPut, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, bytes.NewReader(rawPayload))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	httpClient := &http.Client{
-		Transport: d.Client.Config.CreateTransport(http.DefaultTransport),
-	}
-	res, err := httpClient.Do(req)
+	endpoint := path.Join("autogen_subdomains", subdomainName, "delegation")
+	headers := map[string]string{"Content-Type": "application/json"}
+	res, err := d.Client.Do(http.MethodPut, endpoint, nil, headers, bytes.NewReader(rawPayload))
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +47,7 @@ func (d *AutogenSubdomainsDelegation) UpdateAutogenSubdomainDelegation(subdomain
 
 // DELETE /orgs/autogen_subdomains/:subdomainId/delegation ...
 func (d *AutogenSubdomainsDelegation) DestroyAutogenSubdomainDelegation(subdomainName string) (found bool, err error) {
-	res, err := d.Client.Do(http.MethodDelete, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, nil)
+	res, err := d.Client.Do(http.MethodDelete, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/autogen_subdomains_delegation.go
+++ b/autogen_subdomains_delegation.go
@@ -13,7 +13,7 @@ type AutogenSubdomainsDelegation struct {
 }
 
 // GET /orgs/autogen_subdomains/:subdomainName/delegation
-func (d *AutogenSubdomainsDelegation) Get(subdomainName string) (*types.AutogenSubdomainDelegation, error) {
+func (d AutogenSubdomainsDelegation) Get(subdomainName string) (*types.AutogenSubdomainDelegation, error) {
 	res, err := d.Client.Do(http.MethodGet, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, nil, nil)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func (d *AutogenSubdomainsDelegation) Get(subdomainName string) (*types.AutogenS
 }
 
 // PUT /orgs/autogen_subdomains/:subdomainId/delegation ...
-func (d *AutogenSubdomainsDelegation) UpdateAutogenSubdomainDelegation(subdomainName string, delegation *types.AutogenSubdomainDelegation) (*types.AutogenSubdomainDelegation, error) {
+func (d AutogenSubdomainsDelegation) Update(subdomainName string, delegation *types.AutogenSubdomainDelegation) (*types.AutogenSubdomainDelegation, error) {
 	rawPayload, _ := json.Marshal(delegation)
 	endpoint := path.Join("autogen_subdomains", subdomainName, "delegation")
 	headers := map[string]string{"Content-Type": "application/json"}
@@ -46,7 +46,7 @@ func (d *AutogenSubdomainsDelegation) UpdateAutogenSubdomainDelegation(subdomain
 }
 
 // DELETE /orgs/autogen_subdomains/:subdomainId/delegation ...
-func (d *AutogenSubdomainsDelegation) DestroyAutogenSubdomainDelegation(subdomainName string) (found bool, err error) {
+func (d AutogenSubdomainsDelegation) Destroy(subdomainName string) (found bool, err error) {
 	res, err := d.Client.Do(http.MethodDelete, path.Join("autogen_subdomains", subdomainName, "delegation"), nil, nil, nil)
 	if err != nil {
 		return false, err

--- a/client.go
+++ b/client.go
@@ -25,6 +25,10 @@ func (c *Client) AutogenSubdomains() AutogenSubdomains {
 	return AutogenSubdomains{Client: c}
 }
 
+func (c *Client) AutogenSubdomainsDelegation() AutogenSubdomainsDelegation {
+	return AutogenSubdomainsDelegation{Client: c}
+}
+
 func (c *Client) Do(method string, relativePath string, query url.Values, body io.Reader) (*http.Response, error) {
 	req, err := c.CreateRequest(method, relativePath, query, body)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -21,6 +21,10 @@ func (c *Client) Workspaces() Workspaces {
 	return Workspaces{Client: c}
 }
 
+func (c *Client) RunConfigs() RunConfigs {
+	return RunConfigs{Client: c}
+}
+
 func (c *Client) AutogenSubdomains() AutogenSubdomains {
 	return AutogenSubdomains{Client: c}
 }

--- a/client.go
+++ b/client.go
@@ -21,6 +21,10 @@ func (c *Client) Workspaces() Workspaces {
 	return Workspaces{Client: c}
 }
 
+func (c *Client) AutogenSubdomains() AutogenSubdomains {
+	return AutogenSubdomains{Client: c}
+}
+
 func (c *Client) Do(method string, relativePath string, query url.Values, body io.Reader) (*http.Response, error) {
 	req, err := c.CreateRequest(method, relativePath, query, body)
 	if err != nil {
@@ -48,6 +52,18 @@ func (c *Client) ReadJsonResponse(res *http.Response, obj interface{}) error {
 	decoder := json.NewDecoder(res.Body)
 	if err := decoder.Decode(obj); err != nil {
 		return fmt.Errorf("error decoding json body: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) VerifyResponse(res *http.Response) error {
+	if res.StatusCode >= 400 {
+		raw, _ := ioutil.ReadAll(res.Body)
+		return &HttpError{
+			StatusCode: res.StatusCode,
+			Status:     res.Status,
+			Body:       string(raw),
+		}
 	}
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -29,10 +29,13 @@ func (c *Client) AutogenSubdomainsDelegation() AutogenSubdomainsDelegation {
 	return AutogenSubdomainsDelegation{Client: c}
 }
 
-func (c *Client) Do(method string, relativePath string, query url.Values, body io.Reader) (*http.Response, error) {
+func (c *Client) Do(method string, relativePath string, query url.Values, headers map[string]string, body io.Reader) (*http.Response, error) {
 	req, err := c.CreateRequest(method, relativePath, query, body)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	httpClient := &http.Client{

--- a/run_configs.go
+++ b/run_configs.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/google/uuid"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"net/http"
+	"path"
+)
+
+type RunConfigs struct {
+	Client *Client
+}
+
+func (c RunConfigs) GetLatest(stackName string, workspaceUid uuid.UUID) (*types.RunConfig, error) {
+	res, err := c.Client.Do(http.MethodGet, path.Join("stacks", stackName, "workspaces", workspaceUid.String(), "run-configs", "latest"), nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var runConfig types.RunConfig
+	if err := c.Client.ReadJsonResponse(res, &runConfig); IsNotFoundError(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return &runConfig, nil
+}

--- a/types/autogen_subdomain_delegation.go
+++ b/types/autogen_subdomain_delegation.go
@@ -1,0 +1,7 @@
+package types
+
+type AutogenSubdomainDelegation struct {
+	Nameservers Nameservers `json:"nameservers"`
+}
+
+type Nameservers []string

--- a/workspaces.go
+++ b/workspaces.go
@@ -11,7 +11,7 @@ type Workspaces struct {
 }
 
 func (w Workspaces) Get(stackName, blockName, envName string) (*types.Workspace, error) {
-	res, err := w.Client.Do(http.MethodGet, path.Join("stacks", stackName, "blocks", blockName, "envs", envName), nil, nil)
+	res, err := w.Client.Do(http.MethodGet, path.Join("stacks", stackName, "blocks", blockName, "envs", envName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds REST endpoints for managing autogen subdomains and autogen subdomains delegation.
Additionally, this adds `.../run-configs/latest`.
This is necessary to add `resource "autogen_subdomain" ...` to `terraform-provider-ns`.