### PR TITLE
Adding `/orgs/:org/stacks` to client

### DIFF
--- a/stacks_by_name.go
+++ b/stacks_by_name.go
@@ -2,18 +2,42 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"net/http"
-	"path"
 )
 
 type StacksByName struct {
 	Client *Client
 }
 
+func (s StacksByName) basePath() string {
+	return "stacks"
+}
+
+func (s StacksByName) stackPath(stackName string) string {
+	return fmt.Sprintf("stacks/%s", stackName)
+}
+
+// List - GET /orgs/:orgName/stacks
+func (s StacksByName) List() ([]*types.Stack, error) {
+	res, err := s.Client.Do(http.MethodGet, s.basePath(), nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var stacks []*types.Stack
+	if err := s.Client.ReadJsonResponse(res, &stacks); IsNotFoundError(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return stacks, nil
+}
+
 // Get - GET /orgs/:orgName/stacks/:name
 func (s StacksByName) Get(stackName string) (*types.Stack, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("stacks", stackName), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodGet, s.stackPath(stackName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -30,8 +54,7 @@ func (s StacksByName) Get(stackName string) (*types.Stack, error) {
 // Upsert - PUT/PATCH /orgs/:orgName/stacks/:name
 func (s StacksByName) Upsert(stackName string, stack *types.Stack) (*types.Stack, error) {
 	rawPayload, _ := json.Marshal(stack)
-	endpoint := path.Join("stacks", stackName)
-	res, err := s.Client.Do(http.MethodPut, endpoint, nil, nil, json.RawMessage(rawPayload))
+	res, err := s.Client.Do(http.MethodPut, s.stackPath(stackName), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds `/orgs/:org/stacks` to `StacksByName` client.
This was necessary to make `stacks list` CLI command work.
`/orgs/:org/stacks_by_id` is not currently exposed through api gateway.
I expect this to change in the future with dropping "by name" endpoints, but this was a small enough change to warrant making stacks list work.