### PR TITLE
C369/autogen env

### DIFF
--- a/autogen_subdomain.go
+++ b/autogen_subdomain.go
@@ -10,13 +10,13 @@ type AutogenSubdomain struct {
 	Client *Client
 }
 
-func (d AutogenSubdomain) path(subdomainId int64, envName string) string {
-	return fmt.Sprintf("subdomains/%d/envs/%s/autogen_subdomain", subdomainId, envName)
+func (AutogenSubdomain) path(subdomainId, envId int64) string {
+	return fmt.Sprintf("subdomains/%d/envs/%d/autogen_subdomain", subdomainId, envId)
 }
 
-// Get - GET /orgs/:orgName/subdomains/:subdomainId/envs/:envName/autogen_subdomain
-func (a AutogenSubdomain) Get(subdomainId int64, envName string) (*types.AutogenSubdomain, error) {
-	res, err := a.Client.Do(http.MethodGet, a.path(subdomainId, envName), nil, nil, nil)
+// Get - GET /orgs/:orgName/subdomains/:subdomainId/envs/:envId/autogen_subdomain
+func (a AutogenSubdomain) Get(subdomainId, envId int64) (*types.AutogenSubdomain, error) {
+	res, err := a.Client.Do(http.MethodGet, a.path(subdomainId, envId), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -30,9 +30,9 @@ func (a AutogenSubdomain) Get(subdomainId int64, envName string) (*types.Autogen
 	return &autogenSubdomain, nil
 }
 
-// Create - POST /orgs/:orgName/subdomains/:subdomainId/envs/:envName/autogen_subdomain
-func (a AutogenSubdomain) Create(subdomainId int64, envName string) (*types.AutogenSubdomain, error) {
-	res, err := a.Client.Do(http.MethodPost, a.path(subdomainId, envName), nil, nil, nil)
+// Create - POST /orgs/:orgName/subdomains/:subdomainId/envs/:envId/autogen_subdomain
+func (a AutogenSubdomain) Create(subdomainId, envId int64) (*types.AutogenSubdomain, error) {
+	res, err := a.Client.Do(http.MethodPost, a.path(subdomainId, envId), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +46,9 @@ func (a AutogenSubdomain) Create(subdomainId int64, envName string) (*types.Auto
 	return &autogenSubdomain, nil
 }
 
-// Destroy - DELETE /orgs/:orgName/subdomains/:subdomainId/envs/:envName/autogen_subdomain
-func (a AutogenSubdomain) Destroy(subdomainId int64, envName string) (bool, error) {
-	res, err := a.Client.Do(http.MethodDelete, a.path(subdomainId, envName), nil, nil, nil)
+// Destroy - DELETE /orgs/:orgName/subdomains/:subdomainId/envs/:envId/autogen_subdomain
+func (a AutogenSubdomain) Destroy(subdomainId, envId int64) (bool, error) {
+	res, err := a.Client.Do(http.MethodDelete, a.path(subdomainId, envId), nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/autogen_subdomain_delegation.go
+++ b/autogen_subdomain_delegation.go
@@ -11,14 +11,14 @@ type AutogenSubdomainDelegation struct {
 	Client *Client
 }
 
-func (d AutogenSubdomainDelegation) path(subdomainId int64, envName string) string {
-	return fmt.Sprintf("subdomains/%d/envs/%s/autogen_subdomain/delegation", subdomainId, envName)
+func (AutogenSubdomainDelegation) path(subdomainId, envId int64) string {
+	return fmt.Sprintf("subdomains/%d/envs/%d/autogen_subdomain/delegation", subdomainId, envId)
 }
 
-// Update - PUT /orgs/:orgName/subdomains/:subdomainId/envs/:envName/autogen_subdomain/delegation
-func (d AutogenSubdomainDelegation) Update(subdomainId int64, envName string, delegation *types.AutogenSubdomain) (*types.AutogenSubdomain, error) {
+// Update - PUT /orgs/:orgName/subdomains/:subdomainId/envs/:envId/autogen_subdomain/delegation
+func (d AutogenSubdomainDelegation) Update(subdomainId, envId int64, delegation *types.AutogenSubdomain) (*types.AutogenSubdomain, error) {
 	rawPayload, _ := json.Marshal(delegation)
-	res, err := d.Client.Do(http.MethodPut, d.path(subdomainId, envName), nil, nil, json.RawMessage(rawPayload))
+	res, err := d.Client.Do(http.MethodPut, d.path(subdomainId, envId), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return nil, err
 	}
@@ -32,9 +32,9 @@ func (d AutogenSubdomainDelegation) Update(subdomainId int64, envName string, de
 	return &updatedDelegation, nil
 }
 
-// Destroy - DELETE /orgs/:orgName/subdomains/:subdomainId/envs/:envName/autogen_subdomain/delegation
-func (d AutogenSubdomainDelegation) Destroy(subdomainId int64, envName string) (found bool, err error) {
-	res, err := d.Client.Do(http.MethodDelete, d.path(subdomainId, envName), nil, nil, nil)
+// Destroy - DELETE /orgs/:orgName/subdomains/:subdomainId/envs/:envId/autogen_subdomain/delegation
+func (d AutogenSubdomainDelegation) Destroy(subdomainId, envId int64) (found bool, err error) {
+	res, err := d.Client.Do(http.MethodDelete, d.path(subdomainId, envId), nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/stacks_by_name.go
+++ b/stacks_by_name.go
@@ -10,6 +10,7 @@ import (
 type StacksByName struct {
 	Client *Client
 }
+
 // Get - GET /orgs/:orgName/stacks_by_name/:name
 func (s StacksByName) Get(stackName string) (*types.Environment, error) {
 	res, err := s.Client.Do(http.MethodGet, path.Join("stacks_by_name", stackName), nil, nil, nil)

--- a/types/workspace.go
+++ b/types/workspace.go
@@ -18,10 +18,10 @@ type Workspace struct {
 	Status   string    `json:"status"`
 	StatusAt time.Time `json:"statusAt"`
 
-	Module            *Module           `json:"module,omitempty"`
-	ActiveRun         *Run              `json:"activeRun,omitempty"`
+	Module          *Module           `json:"module,omitempty"`
+	ActiveRun       *Run              `json:"activeRun,omitempty"`
 	LastFinishedRun *Run              `json:"lastFinishedRun,omitempty"`
-	Dependencies      []WorkspaceTarget `json:"dependencies,omitempty"`
+	Dependencies    []WorkspaceTarget `json:"dependencies,omitempty"`
 
 	// Deprecated
 	StackName string `json:"stackName"`


### PR DESCRIPTION
https://app.ora.pm/p/76fc4569fe5049a6b91710fae25e141b?v=48413&s=18798&t=k&c=f14408a3e5654618a8daeb89f6f66035
This PR allows users to rename environment name without affecting the autogen subdomain.

This PR reindexes autogen subdomains to env id instead of env name.

Dependent on:
- https://github.com/nullstone-io/furion/pull/42