### PR TITLE
gcp credentials in provider

### DIFF
--- a/types/gcp_credentials.go
+++ b/types/gcp_credentials.go
@@ -1,0 +1,23 @@
+package types
+
+const (
+	GcpAuthTypeServiceAccount = "serviceAccount"
+)
+
+type GcpCredentials struct {
+	AuthType          string               `json:"authType"`
+	ServiceAccountKey GcpServiceAccountKey `json:"serviceAccount"`
+}
+
+type GcpServiceAccountKey struct {
+	Type                    string `json:"type"`
+	ProjectId               string `json:"project_id"`
+	PrivateKeyId            string `json:"private_key_id"`
+	PrivateKey              string `json:"private_key"`
+	ClientEmail             string `json:"client_email"`
+	ClientId                string `json:"client_id"`
+	AuthUri                 string `json:"auth_uri"`
+	TokenUri                string `json:"token_uri"`
+	AuthProviderX509CertUrl string `json:"auth_provider_x509_cert_url"`
+	ClientX509CertUrl       string `json:"client_x509_cert_url"`
+}

--- a/types/provider.go
+++ b/types/provider.go
@@ -6,9 +6,14 @@ import (
 
 type Provider struct {
 	IdModel
-	Name         string          `json:"name"`
-	OrgName      string          `json:"orgName"`
-	ProviderType string          `json:"providerType"`
-	ProviderId   string          `json:"providerId"`
-	Credentials  json.RawMessage `json:"credentials,omitempty"`
+	Name         string `json:"name"`
+	OrgName      string `json:"orgName"`
+	ProviderType string `json:"providerType"`
+
+	// ProviderId represents a single namespace for the provider
+	//   AWS: Account ID
+	//   GCP: Project ID
+	ProviderId string `json:"providerId"`
+
+	Credentials json.RawMessage `json:"credentials,omitempty"`
 }

--- a/types/provider_config.go
+++ b/types/provider_config.go
@@ -1,10 +1,17 @@
 package types
 
 type ProviderConfig struct {
-	Aws *AwsProviderConfig `json:"aws"`
+	Aws *AwsProviderConfig `json:"aws,omitempty"`
+	Gcp *GcpProviderConfig `json:"gcp,omitempty"`
 }
 
 type AwsProviderConfig struct {
 	ProviderName string `json:"providerName"`
 	Region       string `json:"region"`
+}
+
+type GcpProviderConfig struct {
+	ProviderName string `json:"providerName"`
+	Region       string `json:"region"`
+	Zone         string `json:"zone"`
 }


### PR DESCRIPTION
This PR adds `gcp` to the provider config for an environment.
This also adds the `GcpCredentials` model that is parsed from the provider credentials json.