### PR TITLE
C730 orgs

### DIFF
--- a/app_capabilities.go
+++ b/app_capabilities.go
@@ -13,11 +13,11 @@ type AppCapabilities struct {
 }
 
 func (e AppCapabilities) basePath(appId int64) string {
-	return fmt.Sprintf("apps/%d/capabilities", appId)
+	return fmt.Sprintf("orgs/%s/apps/%d/capabilities", e.Client.Config.OrgName, appId)
 }
 
 func (e AppCapabilities) capPath(appId, capId int64) string {
-	return fmt.Sprintf("apps/%d/capabilities/%d", appId, capId)
+	return fmt.Sprintf("orgs/%s/apps/%d/capabilities/%d", e.Client.Config.OrgName, appId, capId)
 }
 
 // List - GET /orgs/:orgName/apps/:app_id/capabilities

--- a/app_capabilities.go
+++ b/app_capabilities.go
@@ -28,7 +28,7 @@ func (e AppCapabilities) List(appId int64) ([]types.Capability, error) {
 	}
 
 	var appCaps []types.Capability
-	if err := e.Client.ReadJsonResponse(res, &appCaps); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &appCaps); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (e AppCapabilities) Get(appId, capId int64) (*types.Capability, error) {
 	}
 
 	var appCap types.Capability
-	if err := e.Client.ReadJsonResponse(res, &appCap); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &appCap); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (e AppCapabilities) Create(appId int64, capability *types.Capability) (*typ
 	}
 
 	var updatedCap types.Capability
-	if err := e.Client.ReadJsonResponse(res, &updatedCap); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedCap); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (e AppCapabilities) Update(appId, capId int64, capability *types.Capability
 	}
 
 	var updatedCap types.Capability
-	if err := e.Client.ReadJsonResponse(res, &updatedCap); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedCap); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/app_envs.go
+++ b/app_envs.go
@@ -23,7 +23,7 @@ func (e AppEnvs) Get(appId int64, envName string) (*types.AppEnv, error) {
 	}
 
 	var appEnv types.AppEnv
-	if err := e.Client.ReadJsonResponse(res, &appEnv); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &appEnv); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (e AppEnvs) Update(appId int64, envName string, version string) (*types.App
 	}
 
 	var updated types.AppEnv
-	if err := e.Client.ReadJsonResponse(res, &updated); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updated); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/app_envs.go
+++ b/app_envs.go
@@ -13,7 +13,7 @@ type AppEnvs struct {
 }
 
 func (e AppEnvs) basePath(appId int64, envName string) string {
-	return fmt.Sprintf("apps/%d/envs/%s", appId, envName)
+	return fmt.Sprintf("orgs/%s/apps/%d/envs/%s", e.Client.Config.OrgName, appId, envName)
 }
 
 func (e AppEnvs) Get(appId int64, envName string) (*types.AppEnv, error) {

--- a/apps.go
+++ b/apps.go
@@ -28,7 +28,7 @@ func (a Apps) List() ([]types.Application, error) {
 	}
 
 	var apps []types.Application
-	if err := a.Client.ReadJsonResponse(res, &apps); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &apps); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (a Apps) Get(appId int64) (*types.Application, error) {
 	}
 
 	var app types.Application
-	if err := a.Client.ReadJsonResponse(res, &app); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &app); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (a Apps) Create(app *types.Application) (*types.Application, error) {
 	}
 
 	var updatedApp types.Application
-	if err := a.Client.ReadJsonResponse(res, &updatedApp); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedApp); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (a Apps) Update(appId int64, app *types.Application) (*types.Application, e
 	}
 
 	var updatedApp types.Application
-	if err := a.Client.ReadJsonResponse(res, &updatedApp); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedApp); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/apps.go
+++ b/apps.go
@@ -13,11 +13,11 @@ type Apps struct {
 }
 
 func (a Apps) basePath() string {
-	return fmt.Sprintf("apps")
+	return fmt.Sprintf("orgs/%s/apps", a.Client.Config.OrgName)
 }
 
 func (a Apps) appPath(appId int64) string {
-	return fmt.Sprintf("apps/%d", appId)
+	return fmt.Sprintf("orgs/%s/apps/%d", a.Client.Config.OrgName, appId)
 }
 
 // List - GET /orgs/:orgName/apps

--- a/autogen_subdomain.go
+++ b/autogen_subdomain.go
@@ -23,7 +23,7 @@ func (a AutogenSubdomain) Get(subdomainId, envId int64) (*types.AutogenSubdomain
 	}
 
 	var autogenSubdomain types.AutogenSubdomain
-	if err := a.Client.ReadJsonResponse(res, &autogenSubdomain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &autogenSubdomain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (a AutogenSubdomain) Create(subdomainId, envId int64) (*types.AutogenSubdom
 	}
 
 	var autogenSubdomain types.AutogenSubdomain
-	if err := a.Client.ReadJsonResponse(res, &autogenSubdomain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &autogenSubdomain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/autogen_subdomain.go
+++ b/autogen_subdomain.go
@@ -11,8 +11,8 @@ type AutogenSubdomain struct {
 	Client *Client
 }
 
-func (AutogenSubdomain) path(subdomainId, envId int64) string {
-	return fmt.Sprintf("subdomains/%d/envs/%d/autogen_subdomain", subdomainId, envId)
+func (a AutogenSubdomain) path(subdomainId, envId int64) string {
+	return fmt.Sprintf("orgs/%s/subdomains/%d/envs/%d/autogen_subdomain", a.Client.Config.OrgName, subdomainId, envId)
 }
 
 // Get - GET /orgs/:orgName/subdomains/:subdomainId/envs/:envId/autogen_subdomain

--- a/autogen_subdomain_delegation.go
+++ b/autogen_subdomain_delegation.go
@@ -12,8 +12,8 @@ type AutogenSubdomainDelegation struct {
 	Client *Client
 }
 
-func (AutogenSubdomainDelegation) path(subdomainId, envId int64) string {
-	return fmt.Sprintf("subdomains/%d/envs/%d/autogen_subdomain/delegation", subdomainId, envId)
+func (d AutogenSubdomainDelegation) path(subdomainId, envId int64) string {
+	return fmt.Sprintf("orgs/%s/subdomains/%d/envs/%d/autogen_subdomain/delegation", d.Client.Config.OrgName, subdomainId, envId)
 }
 
 // Update - PUT /orgs/:orgName/subdomains/:subdomainId/envs/:envId/autogen_subdomain/delegation

--- a/autogen_subdomain_delegation.go
+++ b/autogen_subdomain_delegation.go
@@ -25,7 +25,7 @@ func (d AutogenSubdomainDelegation) Update(subdomainId, envId int64, delegation 
 	}
 
 	var updatedDelegation types.AutogenSubdomain
-	if err := d.Client.ReadJsonResponse(res, &updatedDelegation); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedDelegation); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/blocks.go
+++ b/blocks.go
@@ -13,11 +13,11 @@ type Blocks struct {
 }
 
 func (s Blocks) basePath(stackId int64) string {
-	return fmt.Sprintf("stacks/%d/blocks", stackId)
+	return fmt.Sprintf("orgs/%s/stacks/%d/blocks", s.Client.Config.OrgName, stackId)
 }
 
 func (s Blocks) blockPath(stackId, blockId int64) string {
-	return fmt.Sprintf("stacks/%d/blocks/%d", stackId, blockId)
+	return fmt.Sprintf("orgs/%s/stacks/%d/blocks/%d", s.Client.Config.OrgName, stackId, blockId)
 }
 
 // List - GET /orgs/:orgName/stacks/:stack_id/blocks

--- a/blocks.go
+++ b/blocks.go
@@ -28,7 +28,7 @@ func (s Blocks) List(stackId int64) ([]types.Block, error) {
 	}
 
 	var blocks []types.Block
-	if err := s.Client.ReadJsonResponse(res, &blocks); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &blocks); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (s Blocks) Get(stackId, blockId int64) (*types.Block, error) {
 	}
 
 	var block types.Block
-	if err := s.Client.ReadJsonResponse(res, &block); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &block); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (s Blocks) Create(stackId int64, block *types.Block) (*types.Block, error) 
 	}
 
 	var updatedBlock types.Block
-	if err := s.Client.ReadJsonResponse(res, &updatedBlock); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedBlock); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s Blocks) Update(stackId, blockId int64, block *types.Block) (*types.Block
 	}
 
 	var updatedBlock types.Block
-	if err := s.Client.ReadJsonResponse(res, &updatedBlock); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedBlock); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/blocks_by_name.go
+++ b/blocks_by_name.go
@@ -11,9 +11,13 @@ type BlocksByName struct {
 	Client *Client
 }
 
+func (s BlocksByName) blockPath(stackName, blockName string) string {
+	return path.Join("orgs", s.Client.Config.OrgName, "stacks_by_name", stackName, "blocks", blockName)
+}
+
 // Get - GET /orgs/:orgName/stacks_by_name/:stack_name/blocks/:name
 func (s BlocksByName) Get(stackName, blockName string) (*types.Block, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("stacks_by_name", stackName, "blocks", blockName), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodGet, s.blockPath(stackName, blockName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/blocks_by_name.go
+++ b/blocks_by_name.go
@@ -19,7 +19,7 @@ func (s BlocksByName) Get(stackName, blockName string) (*types.Block, error) {
 	}
 
 	var env types.Block
-	if err := s.Client.ReadJsonResponse(res, &env); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &env); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"io"
 	"net/http"
 	"net/url"
@@ -25,6 +24,10 @@ func (c *Client) Org(orgName string) *Client {
 	cfg := c.Config
 	cfg.OrgName = orgName
 	return &Client{Config: cfg}
+}
+
+func (c *Client) Organizations() Organizations {
+	return Organizations{Client: c}
 }
 
 func (c *Client) Stacks() Stacks {
@@ -145,32 +148,6 @@ func (c *Client) Do(method string, relativePath string, query url.Values, header
 		Transport: c.Config.CreateTransport(http.DefaultTransport),
 	}
 	return httpClient.Do(req)
-}
-
-func (c *Client) ReadJsonResponse(res *http.Response, obj interface{}) error {
-	if err := response.Verify(res); err != nil {
-		return err
-	}
-
-	defer res.Body.Close()
-	decoder := json.NewDecoder(res.Body)
-	if err := decoder.Decode(obj); err != nil {
-		return fmt.Errorf("error decoding json body: %w", err)
-	}
-	return nil
-}
-
-func (c *Client) ReadFileResponse(res *http.Response, file io.Writer) error {
-	if err := response.Verify(res); err != nil {
-		return err
-	}
-
-	defer res.Body.Close()
-	_, err := io.Copy(file, res.Body)
-	if err != nil {
-		return fmt.Errorf("error reading file body: %w", err)
-	}
-	return nil
 }
 
 func (c *Client) CreateRequest(method string, relativePath string, query url.Values, body io.Reader) (*http.Request, error) {

--- a/config.go
+++ b/config.go
@@ -43,7 +43,7 @@ func (c *Config) ConstructUrl(relativePath string, query url.Values) (*url.URL, 
 	if err != nil {
 		return nil, fmt.Errorf("invalid nullstone API base address (%s): %w", c.BaseAddress, err)
 	}
-	u.Path = path.Join(u.Path, "orgs", c.OrgName, relativePath)
+	u.Path = path.Join(u.Path, relativePath)
 	if query != nil {
 		u.RawQuery = query.Encode()
 	}

--- a/domains.go
+++ b/domains.go
@@ -13,11 +13,11 @@ type Domains struct {
 }
 
 func (s Domains) basePath() string {
-	return fmt.Sprintf("domains")
+	return fmt.Sprintf("orgs/%s/domains", s.Client.Config.OrgName)
 }
 
 func (s Domains) domainPath(domainId int64) string {
-	return fmt.Sprintf("domains/%d", domainId)
+	return fmt.Sprintf("orgs/%s/domains/%d", s.Client.Config.OrgName, domainId)
 }
 
 // List - GET /orgs/:orgName/domains

--- a/domains.go
+++ b/domains.go
@@ -28,7 +28,7 @@ func (s Domains) List() ([]types.Domain, error) {
 	}
 
 	var domains []types.Domain
-	if err := s.Client.ReadJsonResponse(res, &domains); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &domains); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (s Domains) Get(domainId int64) (*types.Domain, error) {
 	}
 
 	var domain types.Domain
-	if err := s.Client.ReadJsonResponse(res, &domain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &domain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (s Domains) Create(domain *types.Domain) (*types.Domain, error) {
 	}
 
 	var updatedDomain types.Domain
-	if err := s.Client.ReadJsonResponse(res, &updatedDomain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedDomain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s Domains) Update(domainId int64, domain *types.Domain) (*types.Domain, er
 	}
 
 	var updatedDomain types.Domain
-	if err := s.Client.ReadJsonResponse(res, &updatedDomain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedDomain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/domains_by_name.go
+++ b/domains_by_name.go
@@ -1,19 +1,23 @@
 package api
 
 import (
+	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"net/http"
-	"path"
 )
 
 type DomainsByName struct {
 	Client *Client
 }
 
+func (s DomainsByName) domainPath(stackName, domainName string) string {
+	return fmt.Sprintf("orgs/%s/stacks/%s/domains/%s", s.Client.Config.OrgName, stackName, domainName)
+}
+
 // Get - GET /orgs/:orgName/stacks/:stackName/domains/:name
-func (s DomainsByName) Get(stackName string, domainName string) (*types.Domain, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("stacks", stackName, "domains", domainName), nil, nil, nil)
+func (s DomainsByName) Get(stackName, domainName string) (*types.Domain, error) {
+	res, err := s.Client.Do(http.MethodGet, s.domainPath(stackName, domainName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/domains_by_name.go
+++ b/domains_by_name.go
@@ -19,7 +19,7 @@ func (s DomainsByName) Get(stackName string, domainName string) (*types.Domain, 
 	}
 
 	var domain types.Domain
-	if err := s.Client.ReadJsonResponse(res, &domain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &domain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/environments.go
+++ b/environments.go
@@ -13,11 +13,11 @@ type Environments struct {
 }
 
 func (s Environments) basePath(stackId int64) string {
-	return fmt.Sprintf("stacks/%d/envs", stackId)
+	return fmt.Sprintf("orgs/%s/stacks/%d/envs", s.Client.Config.OrgName, stackId)
 }
 
 func (s Environments) envPath(stackId, envId int64) string {
-	return fmt.Sprintf("stacks/%d/envs/%d", stackId, envId)
+	return fmt.Sprintf("orgs/%s/stacks/%d/envs/%d", s.Client.Config.OrgName, stackId, envId)
 }
 
 // List - GET /orgs/:orgName/stacks/:stackId/envs

--- a/environments.go
+++ b/environments.go
@@ -28,7 +28,7 @@ func (s Environments) List(stackId int64) ([]*types.Environment, error) {
 	}
 
 	var envs []*types.Environment
-	if err := s.Client.ReadJsonResponse(res, &envs); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &envs); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (s Environments) Get(stackId, envId int64) (*types.Environment, error) {
 	}
 
 	var env types.Environment
-	if err := s.Client.ReadJsonResponse(res, &env); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &env); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (s Environments) Create(stackId int64, env *types.Environment) (*types.Envi
 	}
 
 	var updatedEnv types.Environment
-	if err := s.Client.ReadJsonResponse(res, &updatedEnv); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedEnv); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s Environments) Update(stackId, envId int64, env *types.Environment) (*typ
 	}
 
 	var updatedEnv types.Environment
-	if err := s.Client.ReadJsonResponse(res, &updatedEnv); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedEnv); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/environments_by_name.go
+++ b/environments_by_name.go
@@ -20,7 +20,7 @@ func (s EnvironmentsByName) Get(stackName, envName string) (*types.Environment, 
 	}
 
 	var env types.Environment
-	if err := s.Client.ReadJsonResponse(res, &env); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &env); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func (s EnvironmentsByName) Upsert(stackName, envName string, env *types.Environ
 	}
 
 	var updatedEnv types.Environment
-	if err := s.Client.ReadJsonResponse(res, &updatedEnv); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedEnv); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/environments_by_name.go
+++ b/environments_by_name.go
@@ -12,9 +12,13 @@ type EnvironmentsByName struct {
 	Client *Client
 }
 
+func (s EnvironmentsByName) path(stackName, envName string) string {
+	return path.Join("orgs", s.Client.Config.OrgName, "stacks_by_name", stackName, "envs", envName)
+}
+
 // Get - GET /orgs/:orgName/stacks_by_name/:stack_name/envs/:name
 func (s EnvironmentsByName) Get(stackName, envName string) (*types.Environment, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("stacks_by_name", stackName, "envs", envName), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodGet, s.path(stackName, envName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +35,7 @@ func (s EnvironmentsByName) Get(stackName, envName string) (*types.Environment, 
 // Upsert - PUT/PATCH /orgs/:orgName/stacks_by_name/:stack_name/envs/:name
 func (s EnvironmentsByName) Upsert(stackName, envName string, env *types.Environment) (*types.Environment, error) {
 	rawPayload, _ := json.Marshal(env)
-	res, err := s.Client.Do(http.MethodPut, path.Join("stacks_by_name", stackName, "envs", envName), nil, nil, json.RawMessage(rawPayload))
+	res, err := s.Client.Do(http.MethodPut, s.path(stackName, envName), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return nil, err
 	}

--- a/find/stack_block_env_by_name.go
+++ b/find/stack_block_env_by_name.go
@@ -9,13 +9,13 @@ import (
 var (
 	ErrStackDoesNotExist = errors.New("stack does not exist")
 	ErrBlockDoesNotExist = errors.New("block does not exist")
-	ErrEnvDoesNotExist = errors.New("env does not exist")
+	ErrEnvDoesNotExist   = errors.New("env does not exist")
 )
 
 type StackBlockEnv struct {
-	Block     types.Block
-	Stack     types.Stack
-	Env       types.Environment
+	Block types.Block
+	Stack types.Stack
+	Env   types.Environment
 }
 
 // StackBlockEnvByName looks for a workspace by stackName, blockName, and envName

--- a/module_versions.go
+++ b/module_versions.go
@@ -24,7 +24,7 @@ func (mv ModuleVersions) List(moduleName string) ([]types.ModuleVersion, error) 
 	}
 
 	var moduleVersions []types.ModuleVersion
-	if err := mv.Client.ReadJsonResponse(res, &moduleVersions); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &moduleVersions); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (mv ModuleVersions) Download(moduleName string, versionName string, file io
 		return err
 	}
 
-	if err := mv.Client.ReadFileResponse(res, file); response.IsNotFoundError(err) {
+	if err := response.ReadFile(res, file); response.IsNotFoundError(err) {
 		return nil
 	} else if err != nil {
 		return err

--- a/module_versions.go
+++ b/module_versions.go
@@ -17,8 +17,16 @@ type ModuleVersions struct {
 	Client *Client
 }
 
+func (mv ModuleVersions) path(moduleName string) string {
+	return path.Join("modules", moduleName, "versions")
+}
+
+func (mv ModuleVersions) downloadPath(moduleName, versionName string) string {
+	return path.Join("modules", moduleName, "versions", versionName, "download")
+}
+
 func (mv ModuleVersions) List(moduleName string) ([]types.ModuleVersion, error) {
-	res, err := mv.Client.Do(http.MethodGet, path.Join("modules", moduleName, "versions"), nil, nil, nil)
+	res, err := mv.Client.Do(http.MethodGet, mv.path(moduleName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +41,7 @@ func (mv ModuleVersions) List(moduleName string) ([]types.ModuleVersion, error) 
 }
 
 func (mv ModuleVersions) GetDownloadInfo(moduleName string, versionName string) (*types.ModuleDownloadInfo, error) {
-	endpoint, err := mv.Client.Config.ConstructUrl(path.Join("modules", moduleName, "versions", versionName, "download"), nil)
+	endpoint, err := mv.Client.Config.ConstructUrl(mv.downloadPath(moduleName, versionName), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +75,7 @@ func (mv ModuleVersions) GetDownloadInfo(moduleName string, versionName string) 
 }
 
 func (mv ModuleVersions) Download(moduleName string, versionName string, file io.Writer) error {
-	endpoint := path.Join("modules", moduleName, "versions", versionName, "download")
-	res, err := mv.Client.Do(http.MethodGet, endpoint, nil, nil, nil)
+	res, err := mv.Client.Do(http.MethodGet, mv.downloadPath(moduleName, versionName), nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -82,8 +89,6 @@ func (mv ModuleVersions) Download(moduleName string, versionName string, file io
 }
 
 func (mv ModuleVersions) Create(moduleName string, versionName string, file io.Reader) error {
-	endpoint := path.Join("modules", moduleName, "versions")
-
 	query := url.Values{}
 	query.Set("version", versionName)
 
@@ -104,7 +109,7 @@ func (mv ModuleVersions) Create(moduleName string, versionName string, file io.R
 
 	var headers = map[string]string{}
 	headers["Content-Type"] = writer.FormDataContentType()
-	res, err := mv.Client.Do(http.MethodPost, endpoint, query, headers, body)
+	res, err := mv.Client.Do(http.MethodPost, mv.path(moduleName), query, headers, body)
 	if err != nil {
 		return err
 	}

--- a/modules.go
+++ b/modules.go
@@ -19,7 +19,7 @@ func (m Modules) List() ([]types.Module, error) {
 	}
 
 	var modules []types.Module
-	if err := m.Client.ReadJsonResponse(res, &modules); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &modules); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (m Modules) Get(moduleName string) (*types.Module, error) {
 	}
 
 	var module types.Module
-	if err := m.Client.ReadJsonResponse(res, &module); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &module); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/modules.go
+++ b/modules.go
@@ -2,18 +2,26 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"net/http"
-	"path"
 )
 
 type Modules struct {
 	Client *Client
 }
 
+func (m Modules) basePath() string {
+	return fmt.Sprintf("orgs/%s/modules", m.Client.Config.OrgName)
+}
+
+func (m Modules) path(moduleName string) string {
+	return fmt.Sprintf("orgs/%s/modules/%s", m.Client.Config.OrgName, moduleName)
+}
+
 func (m Modules) List() ([]types.Module, error) {
-	res, err := m.Client.Do(http.MethodGet, path.Join("modules"), nil, nil, nil)
+	res, err := m.Client.Do(http.MethodGet, m.basePath(), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +36,7 @@ func (m Modules) List() ([]types.Module, error) {
 }
 
 func (m Modules) Get(moduleName string) (*types.Module, error) {
-	res, err := m.Client.Do(http.MethodGet, path.Join("modules", moduleName), nil, nil, nil)
+	res, err := m.Client.Do(http.MethodGet, m.path(moduleName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +52,7 @@ func (m Modules) Get(moduleName string) (*types.Module, error) {
 
 func (m Modules) Create(module *types.Module) error {
 	rawPayload, _ := json.Marshal(module)
-	res, err := m.Client.Do(http.MethodPost, path.Join("modules"), nil, nil, json.RawMessage(rawPayload))
+	res, err := m.Client.Do(http.MethodPost, m.basePath(), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return err
 	}

--- a/organizations.go
+++ b/organizations.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"fmt"
+	"gopkg.in/nullstone-io/go-api-client.v0/response"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"net/http"
+)
+
+type Organizations struct {
+	Client *Client
+}
+
+func (o Organizations) basePath() string {
+	return fmt.Sprintf("organizations")
+}
+
+// List - GET /organizations
+func (o Organizations) List() ([]types.Organization, error) {
+	res, err := o.Client.Do(http.MethodGet, o.basePath(), nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var orgs []types.Organization
+	if err := response.ReadJson(res, &orgs); response.IsNotFoundError(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return orgs, nil
+}

--- a/provider_credentials.go
+++ b/provider_credentials.go
@@ -19,7 +19,7 @@ func (s ProviderCredentials) Get(providerName string) (*json.RawMessage, error) 
 	}
 
 	var creds json.RawMessage
-	if err := s.Client.ReadJsonResponse(res, &creds); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &creds); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func (s ProviderCredentials) Update(providerName string, credentials interface{}
 	}
 
 	var updatedCreds json.RawMessage
-	if err := s.Client.ReadJsonResponse(res, &updatedCreds); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedCreds); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/provider_credentials.go
+++ b/provider_credentials.go
@@ -2,18 +2,22 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"net/http"
-	"path"
 )
 
 type ProviderCredentials struct {
 	Client *Client
 }
 
+func (s ProviderCredentials) path(providerName string) string {
+	return fmt.Sprintf("orgs/%s/providers/%s/credentials", s.Client.Config.OrgName, providerName)
+}
+
 // Get - GET /orgs/:orgName/providers/:name/credentials
 func (s ProviderCredentials) Get(providerName string) (*json.RawMessage, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("providers", providerName, "credentials"), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodGet, s.path(providerName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -30,8 +34,7 @@ func (s ProviderCredentials) Get(providerName string) (*json.RawMessage, error) 
 // Update - PUT /orgs/:orgName/providers/:name/credentials
 func (s ProviderCredentials) Update(providerName string, credentials interface{}) (*json.RawMessage, error) {
 	rawPayload, _ := json.Marshal(credentials)
-	endpoint := path.Join("providers", providerName, "credentials")
-	res, err := s.Client.Do(http.MethodPut, endpoint, nil, nil, json.RawMessage(rawPayload))
+	res, err := s.Client.Do(http.MethodPut, s.path(providerName), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return nil, err
 	}

--- a/providers.go
+++ b/providers.go
@@ -20,7 +20,7 @@ func (s Providers) List() ([]*types.Provider, error) {
 	}
 
 	var providers []*types.Provider
-	if err := s.Client.ReadJsonResponse(res, &providers); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &providers); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (s Providers) Get(providerName string) (*types.Provider, error) {
 	}
 
 	var provider types.Provider
-	if err := s.Client.ReadJsonResponse(res, &provider); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &provider); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ func (s Providers) Create(provider *types.Provider) (*types.Provider, error) {
 	}
 
 	var updatedProvider types.Provider
-	if err := s.Client.ReadJsonResponse(res, &updatedProvider); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedProvider); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func (s Providers) Update(providerName string, provider *types.Provider) (*types
 	}
 
 	var updatedProvider types.Provider
-	if err := s.Client.ReadJsonResponse(res, &updatedProvider); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedProvider); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/providers.go
+++ b/providers.go
@@ -2,19 +2,27 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"net/http"
-	"path"
 )
 
 type Providers struct {
 	Client *Client
 }
 
+func (s Providers) basePath() string {
+	return fmt.Sprintf("orgs/%s/providers", s.Client.Config.OrgName)
+}
+
+func (s Providers) providerPath(providerName string) string {
+	return fmt.Sprintf("orgs/%s/providers/%s", s.Client.Config.OrgName, providerName)
+}
+
 // List - GET /orgs/:orgName/providers
 func (s Providers) List() ([]*types.Provider, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("providers"), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodGet, s.basePath(), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +38,7 @@ func (s Providers) List() ([]*types.Provider, error) {
 
 // Get - GET /orgs/:orgName/providers/:name
 func (s Providers) Get(providerName string) (*types.Provider, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("providers", providerName), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodGet, s.providerPath(providerName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +55,7 @@ func (s Providers) Get(providerName string) (*types.Provider, error) {
 // Create - POST /orgs/:orgName/providers
 func (s Providers) Create(provider *types.Provider) (*types.Provider, error) {
 	rawPayload, _ := json.Marshal(provider)
-	res, err := s.Client.Do(http.MethodPost, path.Join("providers"), nil, nil, json.RawMessage(rawPayload))
+	res, err := s.Client.Do(http.MethodPost, s.basePath(), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +72,7 @@ func (s Providers) Create(provider *types.Provider) (*types.Provider, error) {
 // Update - PUT/PATCH /orgs/:orgName/providers/:name
 func (s Providers) Update(providerName string, provider *types.Provider) (*types.Provider, error) {
 	rawPayload, _ := json.Marshal(provider)
-	endpoint := path.Join("providers", providerName)
-	res, err := s.Client.Do(http.MethodPut, endpoint, nil, nil, json.RawMessage(rawPayload))
+	res, err := s.Client.Do(http.MethodPut, s.providerPath(providerName), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +88,7 @@ func (s Providers) Update(providerName string, provider *types.Provider) (*types
 
 // Destroy - DELETE /orgs/:orgName/providers/:name
 func (s Providers) Destroy(providerName string) (bool, error) {
-	res, err := s.Client.Do(http.MethodDelete, path.Join("providers", providerName), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodDelete, s.providerPath(providerName), nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/public_module_versions.go
+++ b/public_module_versions.go
@@ -14,8 +14,16 @@ type PublicModuleVersions struct {
 	Client *Client
 }
 
+func (mv PublicModuleVersions) path(moduleName string) string {
+	return path.Join("orgs", mv.Client.Config.OrgName, "public-modules", moduleName, "versions")
+}
+
+func (mv PublicModuleVersions) downloadPath(moduleName, versionName string) string {
+	return path.Join("orgs", mv.Client.Config.OrgName, "public-modules", moduleName, "versions", versionName, "download")
+}
+
 func (mv PublicModuleVersions) List(moduleName string) ([]types.ModuleVersion, error) {
-	res, err := mv.Client.Do(http.MethodGet, path.Join("public-modules", moduleName, "versions"), nil, nil, nil)
+	res, err := mv.Client.Do(http.MethodGet, mv.path(moduleName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +38,7 @@ func (mv PublicModuleVersions) List(moduleName string) ([]types.ModuleVersion, e
 }
 
 func (mv PublicModuleVersions) GetDownloadInfo(moduleName string, versionName string) (*types.ModuleDownloadInfo, error) {
-	endpoint, err := mv.Client.Config.ConstructUrl(path.Join("public-modules", moduleName, "versions", versionName, "download"), nil)
+	endpoint, err := mv.Client.Config.ConstructUrl(mv.downloadPath(moduleName, versionName), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +72,7 @@ func (mv PublicModuleVersions) GetDownloadInfo(moduleName string, versionName st
 }
 
 func (mv PublicModuleVersions) Download(moduleName string, versionName string, file io.Writer) error {
-	endpoint := path.Join("public-modules", moduleName, "versions", versionName, "download")
-	res, err := mv.Client.Do(http.MethodGet, endpoint, nil, nil, nil)
+	res, err := mv.Client.Do(http.MethodGet, mv.downloadPath(moduleName, versionName), nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/public_module_versions.go
+++ b/public_module_versions.go
@@ -21,7 +21,7 @@ func (mv PublicModuleVersions) List(moduleName string) ([]types.ModuleVersion, e
 	}
 
 	var moduleVersions []types.ModuleVersion
-	if err := mv.Client.ReadJsonResponse(res, &moduleVersions); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &moduleVersions); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func (mv PublicModuleVersions) Download(moduleName string, versionName string, f
 		return err
 	}
 
-	if err := mv.Client.ReadFileResponse(res, file); response.IsNotFoundError(err) {
+	if err := response.ReadFile(res, file); response.IsNotFoundError(err) {
 		return nil
 	} else if err != nil {
 		return err

--- a/public_modules.go
+++ b/public_modules.go
@@ -18,7 +18,7 @@ func (m PublicModules) List() ([]types.Module, error) {
 	}
 
 	var modules []types.Module
-	if err := m.Client.ReadJsonResponse(res, &modules); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &modules); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func (m PublicModules) Get(moduleName string) (*types.Module, error) {
 	}
 
 	var module types.Module
-	if err := m.Client.ReadJsonResponse(res, &module); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &module); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/public_modules.go
+++ b/public_modules.go
@@ -1,18 +1,26 @@
 package api
 
 import (
+	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"net/http"
-	"path"
 )
 
 type PublicModules struct {
 	Client *Client
 }
 
+func (m PublicModules) basePath() string {
+	return fmt.Sprintf("orgs/%s/public-modules", m.Client.Config.OrgName)
+}
+
+func (m PublicModules) modulePath(moduleName string) string {
+	return fmt.Sprintf("orgs/%s/public-modules/%s", m.Client.Config.OrgName, moduleName)
+}
+
 func (m PublicModules) List() ([]types.Module, error) {
-	res, err := m.Client.Do(http.MethodGet, path.Join("public-modules"), nil, nil, nil)
+	res, err := m.Client.Do(http.MethodGet, m.basePath(), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +35,7 @@ func (m PublicModules) List() ([]types.Module, error) {
 }
 
 func (m PublicModules) Get(moduleName string) (*types.Module, error) {
-	res, err := m.Client.Do(http.MethodGet, path.Join("public-modules", moduleName), nil, nil, nil)
+	res, err := m.Client.Do(http.MethodGet, m.modulePath(moduleName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/response/read_file.go
+++ b/response/read_file.go
@@ -1,0 +1,20 @@
+package response
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func ReadFile(res *http.Response, file io.Writer) error {
+	if err := Verify(res); err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	_, err := io.Copy(file, res.Body)
+	if err != nil {
+		return fmt.Errorf("error reading file body: %w", err)
+	}
+	return nil
+}

--- a/response/read_json.go
+++ b/response/read_json.go
@@ -1,0 +1,20 @@
+package response
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func ReadJson(res *http.Response, obj interface{}) error {
+	if err := Verify(res); err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+	if err := decoder.Decode(obj); err != nil {
+		return fmt.Errorf("error decoding json body: %w", err)
+	}
+	return nil
+}

--- a/run_configs.go
+++ b/run_configs.go
@@ -20,7 +20,7 @@ func (c RunConfigs) GetLatest(stackId int64, workspaceUid uuid.UUID) (*types.Run
 	}
 
 	var runConfig types.RunConfig
-	if err := c.Client.ReadJsonResponse(res, &runConfig); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &runConfig); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/run_configs.go
+++ b/run_configs.go
@@ -12,9 +12,12 @@ type RunConfigs struct {
 	Client *Client
 }
 
+func (c RunConfigs) runConfigPath(stackId int64, workspaceUid uuid.UUID) string {
+	return fmt.Sprintf("orgs/%s/stacks/%d/workspaces/%s/run-configs/latest", c.Client.Config.OrgName, stackId, workspaceUid)
+}
+
 func (c RunConfigs) GetLatest(stackId int64, workspaceUid uuid.UUID) (*types.RunConfig, error) {
-	endpoint := fmt.Sprintf("stacks/%d/workspaces/%s/run-configs/latest", stackId, workspaceUid)
-	res, err := c.Client.Do(http.MethodGet, endpoint, nil, nil, nil)
+	res, err := c.Client.Do(http.MethodGet, c.runConfigPath(stackId, workspaceUid), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/stacks.go
+++ b/stacks.go
@@ -13,11 +13,11 @@ type Stacks struct {
 }
 
 func (s Stacks) basePath() string {
-	return "stacks"
+	return fmt.Sprintf("orgs/%s/stacks", s.Client.Config.OrgName)
 }
 
 func (s Stacks) stackPath(stackId int64) string {
-	return fmt.Sprintf("stacks/%d", stackId)
+	return fmt.Sprintf("orgs/%s/stacks/%d", s.Client.Config.OrgName, stackId)
 }
 
 // List - GET /orgs/:orgName/stacks

--- a/stacks.go
+++ b/stacks.go
@@ -28,7 +28,7 @@ func (s Stacks) List() ([]*types.Stack, error) {
 	}
 
 	var stacks []*types.Stack
-	if err := s.Client.ReadJsonResponse(res, &stacks); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &stacks); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (s Stacks) Get(stackId int64) (*types.Stack, error) {
 	}
 
 	var stack types.Stack
-	if err := s.Client.ReadJsonResponse(res, &stack); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &stack); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (s Stacks) Create(stack *types.Stack) (*types.Stack, error) {
 	}
 
 	var updatedStack types.Stack
-	if err := s.Client.ReadJsonResponse(res, &updatedStack); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedStack); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s Stacks) Update(stackId int64, stack *types.Stack) (*types.Stack, error) 
 	}
 
 	var updatedStack types.Stack
-	if err := s.Client.ReadJsonResponse(res, &updatedStack); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedStack); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/stacks_by_name.go
+++ b/stacks_by_name.go
@@ -12,9 +12,13 @@ type StacksByName struct {
 	Client *Client
 }
 
+func (s StacksByName) stackPath(stackName string) string {
+	return path.Join("orgs", s.Client.Config.OrgName, "stacks_by_name", stackName)
+}
+
 // Get - GET /orgs/:orgName/stacks_by_name/:name
 func (s StacksByName) Get(stackName string) (*types.Stack, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("stacks_by_name", stackName), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodGet, s.stackPath(stackName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -31,8 +35,7 @@ func (s StacksByName) Get(stackName string) (*types.Stack, error) {
 // Upsert - PUT/PATCH /orgs/:orgName/stacks_by_name/:name
 func (s StacksByName) Upsert(stackName string, stack *types.Stack) (*types.Stack, error) {
 	rawPayload, _ := json.Marshal(stack)
-	endpoint := path.Join("stacks_by_name", stackName)
-	res, err := s.Client.Do(http.MethodPut, endpoint, nil, nil, json.RawMessage(rawPayload))
+	res, err := s.Client.Do(http.MethodPut, s.stackPath(stackName), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return nil, err
 	}

--- a/stacks_by_name.go
+++ b/stacks_by_name.go
@@ -20,7 +20,7 @@ func (s StacksByName) Get(stackName string) (*types.Stack, error) {
 	}
 
 	var stack types.Stack
-	if err := s.Client.ReadJsonResponse(res, &stack); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &stack); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (s StacksByName) Upsert(stackName string, stack *types.Stack) (*types.Stack
 	}
 
 	var updatedStack types.Stack
-	if err := s.Client.ReadJsonResponse(res, &updatedStack); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedStack); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/subdomains.go
+++ b/subdomains.go
@@ -28,7 +28,7 @@ func (s Subdomains) List() ([]types.Subdomain, error) {
 	}
 
 	var subdomains []types.Subdomain
-	if err := s.Client.ReadJsonResponse(res, &subdomains); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &subdomains); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (s Subdomains) Get(subdomainId int64) (*types.Subdomain, error) {
 	}
 
 	var subdomain types.Subdomain
-	if err := s.Client.ReadJsonResponse(res, &subdomain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &subdomain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (s Subdomains) Create(subdomain *types.Subdomain) (*types.Subdomain, error)
 	}
 
 	var updatedDomain types.Subdomain
-	if err := s.Client.ReadJsonResponse(res, &updatedDomain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedDomain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s Subdomains) Update(subdomainId int64, subdomain *types.Subdomain) (*type
 	}
 
 	var updatedDomain types.Subdomain
-	if err := s.Client.ReadJsonResponse(res, &updatedDomain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &updatedDomain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/subdomains.go
+++ b/subdomains.go
@@ -13,11 +13,11 @@ type Subdomains struct {
 }
 
 func (s Subdomains) basePath() string {
-	return fmt.Sprintf("subdomains")
+	return fmt.Sprintf("orgs/%s/subdomains", s.Client.Config.OrgName)
 }
 
 func (s Subdomains) subdomainPath(subdomainId int64) string {
-	return fmt.Sprintf("subdomains/%d", subdomainId)
+	return fmt.Sprintf("orgs/%s/subdomains/%d", s.Client.Config.OrgName, subdomainId)
 }
 
 // List - GET /orgs/:orgName/subdomains

--- a/subdomains_by_name.go
+++ b/subdomains_by_name.go
@@ -11,9 +11,13 @@ type SubdomainsByName struct {
 	Client *Client
 }
 
+func (s SubdomainsByName) subdomainPath(stackName, subdomainName string) string {
+	return path.Join("orgs", s.Client.Config.OrgName, "stacks", stackName, "subdomains", subdomainName)
+}
+
 // Get - GET /orgs/:orgName/stacks/:stackName/subdomains/:name
 func (s SubdomainsByName) Get(stackName string, subdomainName string) (*types.Subdomain, error) {
-	res, err := s.Client.Do(http.MethodGet, path.Join("stacks", stackName, "subdomains", subdomainName), nil, nil, nil)
+	res, err := s.Client.Do(http.MethodGet, s.subdomainPath(stackName, subdomainName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/subdomains_by_name.go
+++ b/subdomains_by_name.go
@@ -19,7 +19,7 @@ func (s SubdomainsByName) Get(stackName string, subdomainName string) (*types.Su
 	}
 
 	var subdomain types.Subdomain
-	if err := s.Client.ReadJsonResponse(res, &subdomain); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &subdomain); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/types/organization.go
+++ b/types/organization.go
@@ -1,0 +1,8 @@
+package types
+
+type Organization struct {
+	Name               string `json:"name"`
+	Seats              int    `json:"seats"`
+	Plan               string `json:"plan"`
+	SubscriptionStatus string `json:"subscriptionStatus"`
+}

--- a/workspace_outputs.go
+++ b/workspace_outputs.go
@@ -11,9 +11,12 @@ type WorkspaceOutputs struct {
 	Client *Client
 }
 
+func (w WorkspaceOutputs) workspaceOutputsPath(stackId, blockId, envId int64) string {
+	return fmt.Sprintf("orgs/%s/stacks/%d/blocks/%d/envs/%d/outputs/latest", w.Client.Config.OrgName, stackId, blockId, envId)
+}
+
 func (w WorkspaceOutputs) GetLatest(stackId, blockId, envId int64) (*types.Outputs, error) {
-	endpoint := fmt.Sprintf("stacks/%d/blocks/%d/envs/%d/outputs/latest", stackId, blockId, envId)
-	res, err := w.Client.Do(http.MethodGet, endpoint, nil, nil, nil)
+	res, err := w.Client.Do(http.MethodGet, w.workspaceOutputsPath(stackId, blockId, envId), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/workspace_outputs.go
+++ b/workspace_outputs.go
@@ -19,7 +19,7 @@ func (w WorkspaceOutputs) GetLatest(stackId, blockId, envId int64) (*types.Outpu
 	}
 
 	var outputs types.Outputs
-	if err := w.Client.ReadJsonResponse(res, &outputs); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &outputs); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/workspaces.go
+++ b/workspaces.go
@@ -19,7 +19,7 @@ func (w Workspaces) Get(stackId, blockId, envId int64) (*types.Workspace, error)
 	}
 
 	var workspace types.Workspace
-	if err := w.Client.ReadJsonResponse(res, &workspace); response.IsNotFoundError(err) {
+	if err := response.ReadJson(res, &workspace); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/workspaces.go
+++ b/workspaces.go
@@ -11,9 +11,13 @@ type Workspaces struct {
 	Client *Client
 }
 
+func (w Workspaces) workspacePath(stackId, blockId, envId int64) string {
+	return fmt.Sprintf("orgs/%s/stacks/%d/blocks/%d/envs/%d", w.Client.Config.OrgName, stackId, blockId, envId)
+}
+
+// Get - GET /orgs/:orgName/stacks/:stackId/blocks/:blockId/envs/:envId
 func (w Workspaces) Get(stackId, blockId, envId int64) (*types.Workspace, error) {
-	endpoint := fmt.Sprintf("stacks/%d/blocks/%d/envs/%d", stackId, blockId, envId)
-	res, err := w.Client.Do(http.MethodGet, endpoint, nil, nil, nil)
+	res, err := w.Client.Do(http.MethodGet, w.workspacePath(stackId, blockId, envId), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds Organizations List endpoint to the API client.
This is necessary for `nullstone modules new` command.

The base client does *too* much and got in the way of this PR so I did the following:
- Stripped `/orgs/:orgName` prefix from base client and moved to each API endpoint
- Moved `ReadJson` and `ReadFile` helpers into `response` package.
