### PR TITLE
C1012 runs live streaming

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,8 +98,8 @@ func (c *Client) PromotionConfigs() PromotionConfigs {
 	return PromotionConfigs{Client: c}
 }
 
-func (c *Client) RunLiveLogs() RunLiveLogs {
-	return RunLiveLogs{Client: c}
+func (c *Client) RunLogs() RunLogs {
+	return RunLogs{Client: c}
 }
 
 func (c *Client) AutogenSubdomain() AutogenSubdomain {

--- a/run_logs.go
+++ b/run_logs.go
@@ -8,15 +8,15 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/ws"
 )
 
-type RunLiveLogs struct {
+type RunLogs struct {
 	Client *Client
 }
 
-func (l RunLiveLogs) path(stackId int64, runUid uuid.UUID) string {
-	return fmt.Sprintf("/orgs/%s/stacks/%d/runs/%s/live_logs", l.Client.Config.OrgName, stackId, runUid)
+func (l RunLogs) path(stackId int64, runUid uuid.UUID) string {
+	return fmt.Sprintf("/orgs/%s/stacks/%d/runs/%s/logs", l.Client.Config.OrgName, stackId, runUid)
 }
 
-func (l RunLiveLogs) Watch(ctx context.Context, stackId int64, runUid uuid.UUID, retryFn ws.StreamerRetryFunc) (<-chan types.Message, error) {
+func (l RunLogs) Watch(ctx context.Context, stackId int64, runUid uuid.UUID, retryFn ws.StreamerRetryFunc) (<-chan types.Message, error) {
 	endpoint, headers, err := l.Client.Config.ConstructWsEndpoint(l.path(stackId, runUid))
 	if err != nil {
 		return nil, err

--- a/types/websocket_message.go
+++ b/types/websocket_message.go
@@ -1,7 +1,7 @@
 package types
 
 type Message struct {
-	Source  string `json:"source"`
+	Type    string `json:"type"`
 	Context string `json:"context"`
 	Content string `json:"content"`
 }

--- a/ws/stream_logs.go
+++ b/ws/stream_logs.go
@@ -22,7 +22,7 @@ func StreamLogs(ctx context.Context, endpoint string, headers http.Header, retry
 			var msg types.Message
 			if err := json.Unmarshal(raw, &msg); err != nil {
 				msg = types.Message{
-					Source:  "error",
+					Type:    "error",
 					Content: fmt.Sprintf("error reading log: %s\n", err),
 				}
 			}

--- a/ws/stream_logs_test.go
+++ b/ws/stream_logs_test.go
@@ -33,17 +33,14 @@ func TestStreamLogs(t *testing.T) {
 			name: "send 3 messages and EOT",
 			messages: []types.Message{
 				{
-					Source:  "queue-1",
 					Context: types.DeployPhaseInit,
 					Content: "message 1\n",
 				},
 				{
-					Source:  "queue-1",
 					Context: types.DeployPhaseCheckout,
 					Content: "message 2\n",
 				},
 				{
-					Source:  "queue-1",
 					Context: types.DeployPhaseCheckout,
 					Content: "message 3\n",
 				},
@@ -54,7 +51,6 @@ func TestStreamLogs(t *testing.T) {
 			name: "send 1 message, client cancels",
 			messages: []types.Message{
 				{
-					Source:  "queue-1",
 					Context: types.DeployPhaseInit,
 					Content: "message 1\n",
 				},


### PR DESCRIPTION
This PR updates the go-api-client to match the updated endpoints for streaming deploy_logs and run_logs.