### PR TITLE
Add namespace and env prefix to capability config

### DIFF
--- a/types/capability_config.go
+++ b/types/capability_config.go
@@ -10,6 +10,7 @@ type CapabilityConfig struct {
 	Variables      Variables   `json:"variables"`
 	Connections    Connections `json:"connections"`
 	NeedsDestroyed bool        `json:"needsDestroyed"`
+	Namespace      string      `json:"namespace"`
 }
 
 func (c CapabilityConfig) TfModuleAddr() string {
@@ -18,4 +19,11 @@ func (c CapabilityConfig) TfModuleAddr() string {
 
 func (c CapabilityConfig) TfModuleName() string {
 	return fmt.Sprintf("cap_%d", c.Id)
+}
+
+func (c CapabilityConfig) EnvPrefix() string {
+	if c.Namespace == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s_", c.Namespace)
 }

--- a/types/capability_config.go
+++ b/types/capability_config.go
@@ -1,6 +1,9 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type CapabilityConfig struct {
 	Id             int64       `json:"id"`
@@ -25,5 +28,5 @@ func (c CapabilityConfig) EnvPrefix() string {
 	if c.Namespace == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s_", c.Namespace)
+	return fmt.Sprintf("%s_", strings.ToUpper(c.Namespace))
 }


### PR DESCRIPTION
This serves the CLI and run processor that needs this information to generate `capabilities.tf` from `capabilities.tf.tmpl`.
