### PR TITLE
C1111 preview envs

### DIFF
--- a/response/bad_request_error.go
+++ b/response/bad_request_error.go
@@ -9,14 +9,14 @@ import (
 
 type BadRequestError struct {
 	ApiError
-	Details map[string]string `json:"details"`
+	Details []string `json:"details"`
 }
 
 func (e BadRequestError) Error() string {
 	buf := bytes.NewBufferString("")
 	fmt.Fprintf(buf, "[%s][%s] bad request:", e.Url, e.RequestId)
-	for key, value := range e.Details {
-		fmt.Fprintf(buf, "\n  %s: %s", key, value)
+	for _, value := range e.Details {
+		fmt.Fprintf(buf, "\n  %s", value)
 	}
 	return buf.String()
 }

--- a/types/environment.go
+++ b/types/environment.go
@@ -8,5 +8,5 @@ type Environment struct {
 	OrgName        string         `json:"orgName"`
 	StackId        int64          `json:"stackId"`
 	ProviderConfig ProviderConfig `json:"providerConfig"`
-	PipelineOrder  int            `json:"pipelineOrder"`
+	PipelineOrder  *int           `json:"pipelineOrder"`
 }

--- a/types/environment.go
+++ b/types/environment.go
@@ -6,7 +6,6 @@ type Environment struct {
 	Reference      string         `json:"reference"`
 	OrgName        string         `json:"orgName"`
 	StackId        int64          `json:"stackId"`
-	StackName      string         `json:"stackName"`
 	ProviderConfig ProviderConfig `json:"providerConfig"`
 	PipelineOrder  int            `json:"pipelineOrder"`
 }

--- a/types/environment.go
+++ b/types/environment.go
@@ -5,13 +5,13 @@ type EnvironmentType string
 const (
 	EnvTypePipeline EnvironmentType = "PipelineEnv"
 	EnvTypePreview  EnvironmentType = "PreviewEnv"
-	EnvTypeGlobal                   = "GlobalEnv"
+	EnvTypeGlobal   EnvironmentType = "GlobalEnv"
 )
 
 type Environment struct {
 	IdModel
-	Type           string          `json:"type"`
-	Name           EnvironmentType `json:"name"`
+	Type           EnvironmentType `json:"type"`
+	Name           string          `json:"name"`
 	Reference      string          `json:"reference"`
 	OrgName        string          `json:"orgName"`
 	StackId        int64           `json:"stackId"`

--- a/types/environment.go
+++ b/types/environment.go
@@ -2,6 +2,7 @@ package types
 
 type Environment struct {
 	IdModel
+	Type           string         `json:"type"`
 	Name           string         `json:"name"`
 	Reference      string         `json:"reference"`
 	OrgName        string         `json:"orgName"`

--- a/types/environment.go
+++ b/types/environment.go
@@ -1,12 +1,20 @@
 package types
 
+type EnvironmentType string
+
+const (
+	EnvTypePipeline EnvironmentType = "PipelineEnv"
+	EnvTypePreview  EnvironmentType = "PreviewEnv"
+	EnvTypeGlobal                   = "GlobalEnv"
+)
+
 type Environment struct {
 	IdModel
-	Type           string         `json:"type"`
-	Name           string         `json:"name"`
-	Reference      string         `json:"reference"`
-	OrgName        string         `json:"orgName"`
-	StackId        int64          `json:"stackId"`
-	ProviderConfig ProviderConfig `json:"providerConfig"`
-	PipelineOrder  *int           `json:"pipelineOrder"`
+	Type           string          `json:"type"`
+	Name           EnvironmentType `json:"name"`
+	Reference      string          `json:"reference"`
+	OrgName        string          `json:"orgName"`
+	StackId        int64           `json:"stackId"`
+	ProviderConfig ProviderConfig  `json:"providerConfig"`
+	PipelineOrder  *int            `json:"pipelineOrder"`
 }


### PR DESCRIPTION
This PR updates types.Environment to match the furion endpoint.

1. StackName is no longer a part of the response body so therefore removed from this model.
2. PipelineOrder is now optional depending on the environment type, so it is now a nullable pointer.
3. `Type` is now a field on Environment to indicate `PipelineEnv`, `PreviewEnv`, or `GlobalEnv`.