### PR TITLE
F/1195 pending config changes

### DIFF
--- a/app_capabilities.go
+++ b/app_capabilities.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"log"
 	"net/http"
 )
 
@@ -64,7 +65,9 @@ func (e AppCapabilities) Create(stackId, appId int64, capabilities []*types.Capa
 		Blocks:       blocks,
 	}
 	rawPayload, _ := json.Marshal(input)
+	log.Printf("Creating capabilities: %s", rawPayload)
 	res, err := e.Client.Do(http.MethodPost, e.basePath(stackId, appId), nil, nil, json.RawMessage(rawPayload))
+	log.Printf("Created capabilities: %+v\n", res)
 	if err != nil {
 		return nil, err
 	}

--- a/app_capabilities.go
+++ b/app_capabilities.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
-	"log"
 	"net/http"
 )
 
@@ -65,14 +64,10 @@ func (e AppCapabilities) Create(stackId, appId int64, capabilities []*types.Capa
 		Blocks:       blocks,
 	}
 	rawPayload, _ := json.Marshal(input)
-	log.Printf("Creating capabilities: %s", rawPayload)
-	log.Printf("url: %s", e.basePath(stackId, appId))
 	res, err := e.Client.Do(http.MethodPost, e.basePath(stackId, appId), nil, nil, json.RawMessage(rawPayload))
-	log.Printf("Error: %s", err)
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Created capabilities: %+v\n", res)
 
 	var createdCaps []*types.Capability
 	if err := response.ReadJson(res, &createdCaps); response.IsNotFoundError(err) {

--- a/app_capabilities.go
+++ b/app_capabilities.go
@@ -66,19 +66,21 @@ func (e AppCapabilities) Create(stackId, appId int64, capabilities []*types.Capa
 	}
 	rawPayload, _ := json.Marshal(input)
 	log.Printf("Creating capabilities: %s", rawPayload)
+	log.Printf("url: %s", e.basePath(stackId, appId))
 	res, err := e.Client.Do(http.MethodPost, e.basePath(stackId, appId), nil, nil, json.RawMessage(rawPayload))
-	log.Printf("Created capabilities: %+v\n", res)
+	log.Printf("Error: %s", err)
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("Created capabilities: %+v\n", res)
 
-	var updatedCap []*types.Capability
-	if err := response.ReadJson(res, &updatedCap); response.IsNotFoundError(err) {
+	var createdCaps []*types.Capability
+	if err := response.ReadJson(res, &createdCaps); response.IsNotFoundError(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
 	}
-	return updatedCap, nil
+	return createdCaps, nil
 }
 
 // Update - PUT/PATCH /orgs/:orgName/stacks/:stackId/apps/:app_id/capabilities/:id

--- a/types/capability.go
+++ b/types/capability.go
@@ -9,4 +9,5 @@ type Capability struct {
 	ModuleSourceVersion string                      `json:"moduleSourceVersion"`
 	Connections         map[string]ConnectionTarget `json:"connections"`
 	Namespace           string                      `json:"namespace"`
+	Status              string                      `json:"status,omitempty"`
 }

--- a/types/capability.go
+++ b/types/capability.go
@@ -5,9 +5,9 @@ type Capability struct {
 	OrgName             string                      `json:"orgName"`
 	AppId               int64                       `json:"appId"`
 	Name                string                      `json:"name"`
-	ModuleSource        string                      `json:"moduleSource"`
-	ModuleSourceVersion string                      `json:"moduleSourceVersion"`
-	Connections         map[string]ConnectionTarget `json:"connections"`
-	Namespace           string                      `json:"namespace"`
+	ModuleSource        string                      `json:"moduleSource,omitempty"`
+	ModuleSourceVersion string                      `json:"moduleSourceVersion,omitempty"`
+	Connections         map[string]ConnectionTarget `json:"connections,omitempty"`
+	Namespace           string                      `json:"namespace,omitempty"`
 	Status              string                      `json:"status,omitempty"`
 }

--- a/types/connection_target.go
+++ b/types/connection_target.go
@@ -2,7 +2,7 @@ package types
 
 type ConnectionTarget struct {
 	StackId   int64  `json:"stackId"`
-	BlockId   int64  `json:"blockId"`
+	BlockId   int64  `json:"blockId,omitempty"`
 	BlockName string `json:"blockName"`
 	EnvId     *int64 `json:"envId"`
 }

--- a/types/id_model.go
+++ b/types/id_model.go
@@ -3,7 +3,7 @@ package types
 import "time"
 
 type IdModel struct {
-	Id        int64     `json:"id"`
+	Id        int64     `json:"id,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }


### PR DESCRIPTION
Updated to match the furion implementation. The capabilities#create endpoint can accept multiple capabilities as well as multiple additional blocks.

Also updated the `IdModel` implementation to not send along an id of 0 when `.Id` is nil.