### PR TITLE
Added helper to variables to determine whether it has a value

### DIFF
--- a/types/variables.go
+++ b/types/variables.go
@@ -20,6 +20,10 @@ type Variable struct {
 	Unused bool `json:"unused"`
 }
 
+func (v Variable) HasValue() bool {
+	return v.Value != nil && !v.Unused
+}
+
 type VariableInput struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`


### PR DESCRIPTION
When generating capabilities, we check to see if a variable has value using this:
```
{{ if not $value.Unused -}}{{ if $value.Value -}}
```

This does not work properly. Any time the value is `false`, `0`, `[]`, or `{}`, the generation will omit the variable.
It's possible the terraform variable has a non-zero value and the user wants to set the variable to a zero value.
In this case, the user is stuck -- the variable will never be generated in the capability instantiation stanza.

It's not possible to check `$value.Value` against nil in go templates.
This appears to be in the next go upgrade: https://groups.google.com/g/golang-codereviews/c/33mivDgDNks.

Instead, we add a new function on the variable object so that we can use this:
```
{{ if $value.HasValue }}
```
