### PR TITLE
F1303 run with commit sha

### DIFF
--- a/runs/create.go
+++ b/runs/create.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
-func Create(cfg api.Config, workspace types.Workspace, commitSha *string, isApproved *bool, isDestroy bool, destroyDeps string) (*types.Run, error) {
+func Create(cfg api.Config, workspace types.Workspace, commitSha string, isApproved *bool, isDestroy bool, destroyDeps string) (*types.Run, error) {
 	input := types.CreateRunInput{
 		CommitSha:           commitSha,
 		IsDestroy:           isDestroy,

--- a/runs/create.go
+++ b/runs/create.go
@@ -6,8 +6,9 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
-func Create(cfg api.Config, workspace types.Workspace, isApproved *bool, isDestroy bool, destroyDeps string) (*types.Run, error) {
+func Create(cfg api.Config, workspace types.Workspace, commitSha *string, isApproved *bool, isDestroy bool, destroyDeps string) (*types.Run, error) {
 	input := types.CreateRunInput{
+		CommitSha:           commitSha,
 		IsDestroy:           isDestroy,
 		DestroyDependencies: destroyDeps,
 		IsApproved:          isApproved,

--- a/runs/destroy.go
+++ b/runs/destroy.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
-func Destroy(cfg api.Config, stackId, appId, envId int64, deps string, approve bool) (*types.Run, error) {
+func Destroy(cfg api.Config, stackId, appId, envId int64, commitSha *string, deps string, approve bool) (*types.Run, error) {
 	client := api.Client{Config: cfg}
 	workspace, err := client.Workspaces().Get(stackId, appId, envId)
 	if err != nil {
@@ -19,5 +19,5 @@ func Destroy(cfg api.Config, stackId, appId, envId int64, deps string, approve b
 	if approve {
 		isApproved = &approve
 	}
-	return Create(cfg, *workspace, isApproved, true, deps)
+	return Create(cfg, *workspace, commitSha, isApproved, true, deps)
 }

--- a/runs/destroy.go
+++ b/runs/destroy.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
-func Destroy(cfg api.Config, stackId, appId, envId int64, commitSha *string, deps string, approve bool) (*types.Run, error) {
+func Destroy(cfg api.Config, stackId, appId, envId int64, commitSha string, deps string, approve bool) (*types.Run, error) {
 	client := api.Client{Config: cfg}
 	workspace, err := client.Workspaces().Get(stackId, appId, envId)
 	if err != nil {

--- a/runs/launch.go
+++ b/runs/launch.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
-func Launch(cfg api.Config, stackId, appId, envId int64, approve bool) (*types.Run, error) {
+func Launch(cfg api.Config, stackId, appId, envId int64, commitSha *string, approve bool) (*types.Run, error) {
 	client := api.Client{Config: cfg}
 	workspace, err := client.Workspaces().Get(stackId, appId, envId)
 	if err != nil {
@@ -17,5 +17,5 @@ func Launch(cfg api.Config, stackId, appId, envId int64, approve bool) (*types.R
 	if approve {
 		isApproved = &approve
 	}
-	return Create(cfg, *workspace, isApproved, false, "")
+	return Create(cfg, *workspace, commitSha, isApproved, false, "")
 }

--- a/runs/launch.go
+++ b/runs/launch.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
-func Launch(cfg api.Config, stackId, appId, envId int64, commitSha *string, approve bool) (*types.Run, error) {
+func Launch(cfg api.Config, stackId, appId, envId int64, commitSha string, approve bool) (*types.Run, error) {
 	client := api.Client{Config: cfg}
 	workspace, err := client.Workspaces().Get(stackId, appId, envId)
 	if err != nil {

--- a/types/create_run_input.go
+++ b/types/create_run_input.go
@@ -1,6 +1,8 @@
 package types
 
 type CreateRunInput struct {
+	CommitSha *string `json:"commitSha"`
+
 	// Create a run that destroys this workspace
 	IsDestroy bool `json:"isDestroy"`
 

--- a/types/create_run_input.go
+++ b/types/create_run_input.go
@@ -1,7 +1,7 @@
 package types
 
 type CreateRunInput struct {
-	CommitSha *string `json:"commitSha"`
+	CommitSha string `json:"commitSha"`
 
 	// Create a run that destroys this workspace
 	IsDestroy bool `json:"isDestroy"`

--- a/types/run.go
+++ b/types/run.go
@@ -38,6 +38,7 @@ func IsTerminalRunStatus(runStatus string) bool {
 type Run struct {
 	UidCreatedModel
 	WorkspaceUid uuid.UUID `json:"workspaceUid"`
+	CommitSha    *string   `json:"commitSha"`
 
 	// IsDestroy determines whether to run a destroy plan instead of an apply plan
 	IsDestroy bool `json:"isDestroy"`

--- a/types/run.go
+++ b/types/run.go
@@ -38,7 +38,7 @@ func IsTerminalRunStatus(runStatus string) bool {
 type Run struct {
 	UidCreatedModel
 	WorkspaceUid uuid.UUID `json:"workspaceUid"`
-	CommitSha    *string   `json:"commitSha"`
+	CommitSha    string    `json:"commitSha"`
 
 	// IsDestroy determines whether to run a destroy plan instead of an apply plan
 	IsDestroy bool `json:"isDestroy"`


### PR DESCRIPTION
This PR updates the types.Run to include the CommitSha. It also updates the runs helper methods (create, launch, destroy) to take in a commit_sha and pass it through when creating a run.