### PR TITLE
Fix validation of capability module contracts

### DIFF
--- a/types/module_contract_name.go
+++ b/types/module_contract_name.go
@@ -56,18 +56,14 @@ func (cn ModuleContractName) String() string {
 // Typically, a connection or module (`other`) is validated to follow the contract (`cn`)
 func (cn ModuleContractName) Match(other ModuleContractName) bool {
 	// if the provider is a set of providers, we will check to see if ANY of the providers match
-	// if so, we will set the other.provider to * so that the matchContractPart below will always match
+	// if so, we will set the other.provider to cn.Provider so that the matchContractPart below will always match
 	// this is essentially moving the provider check here
-	if cn.Provider == "*" {
-		// if the source is *, set the "other" to * so that it will always matchContractPart below
-		other.Provider = "*"
-	} else {
-		// if ANY of the providers from "other" match the source, set the "other" to * so that it will always matchContractPart below
+	if cn.Provider != "*" {
 		pts := strings.Split(other.Provider, ",")
 		if len(pts) > 1 {
 			for _, pt := range pts {
 				if pt == cn.Provider {
-					other.Provider = "*"
+					other.Provider = cn.Provider
 					break
 				}
 			}


### PR DESCRIPTION
This fixes an issue where a capability with provider types `aws,gcp` was invalid.