### PR TITLE
Find module

### DIFF
--- a/artifacts/module_source.go
+++ b/artifacts/module_source.go
@@ -2,6 +2,8 @@ package artifacts
 
 import (
 	"errors"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"net/url"
 	"strings"
 )
 
@@ -45,4 +47,10 @@ func (s ModuleSource) String() string {
 	}
 	tokens = append(tokens, s.ModuleName)
 	return strings.Join(tokens, "/")
+}
+
+func (s ModuleSource) OverrideBaseAddress(cfg *api.Config) {
+	if s.Host != "" {
+		cfg.BaseAddress = (&url.URL{Host: s.Host}).String()
+	}
 }

--- a/find/module.go
+++ b/find/module.go
@@ -12,9 +12,10 @@ func Module(cfg api.Config, moduleSource string) (*types.Module, error) {
 	if err != nil {
 		return nil, err
 	}
+	ms.OverrideBaseAddress(&cfg)
 
 	client := api.Client{Config: cfg}
-	module, err := client.Org(ms.OrgName).Modules().Get(ms.ModuleName)
+	module, err := client.Modules().Get(ms.OrgName, ms.ModuleName)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving module: %w", err)
 	} else if module == nil {

--- a/find/module_download_url.go
+++ b/find/module_download_url.go
@@ -1,0 +1,25 @@
+package find
+
+import (
+	"fmt"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"gopkg.in/nullstone-io/go-api-client.v0/artifacts"
+)
+
+func ModuleDownloadUrl(cfg api.Config, source, version string) (string, error) {
+	ms, err := artifacts.ParseSource(source)
+	if err != nil {
+		return "", err
+	}
+	ms.OverrideBaseAddress(&cfg)
+
+	client := api.Client{Config: cfg}
+	info, err := client.ModuleVersions().GetDownloadInfo(ms.OrgName, ms.ModuleName, version)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving artifact info: %w", err)
+	} else if info == nil {
+		return "", fmt.Errorf("module version %s@%s does not exist in registry", source, version)
+	}
+	return info.GetterUrl(), nil
+
+}

--- a/find/module_version.go
+++ b/find/module_version.go
@@ -12,9 +12,10 @@ func ModuleVersion(cfg api.Config, moduleSource, moduleSourceVersion string) (*t
 	if err != nil {
 		return nil, err
 	}
+	ms.OverrideBaseAddress(&cfg)
 
 	client := api.Client{Config: cfg}
-	versions, err := client.Org(ms.OrgName).ModuleVersions().List(ms.ModuleName)
+	versions, err := client.ModuleVersions().List(ms.OrgName, ms.ModuleName)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving module versions: %w", err)
 	} else if versions == nil {

--- a/modules.go
+++ b/modules.go
@@ -12,33 +12,33 @@ type Modules struct {
 	Client *Client
 }
 
-func (m Modules) basePath() string {
-	return fmt.Sprintf("orgs/%s/modules", m.Client.Config.OrgName)
+func (m Modules) basePath(orgName string) string {
+	return fmt.Sprintf("orgs/%s/modules", orgName)
 }
 
-func (m Modules) path(moduleName string) string {
-	return fmt.Sprintf("orgs/%s/modules/%s", m.Client.Config.OrgName, moduleName)
+func (m Modules) path(orgName, moduleName string) string {
+	return fmt.Sprintf("orgs/%s/modules/%s", orgName, moduleName)
 }
 
-func (m Modules) List() ([]types.Module, error) {
-	res, err := m.Client.Do(http.MethodGet, m.basePath(), nil, nil, nil)
+func (m Modules) List(orgName string) ([]types.Module, error) {
+	res, err := m.Client.Do(http.MethodGet, m.basePath(orgName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 	return response.ReadJsonVal[[]types.Module](res)
 }
 
-func (m Modules) Get(moduleName string) (*types.Module, error) {
-	res, err := m.Client.Do(http.MethodGet, m.path(moduleName), nil, nil, nil)
+func (m Modules) Get(orgName, moduleName string) (*types.Module, error) {
+	res, err := m.Client.Do(http.MethodGet, m.path(orgName, moduleName), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 	return response.ReadJsonPtr[types.Module](res)
 }
 
-func (m Modules) Create(module *types.Module) error {
+func (m Modules) Create(orgName string, module *types.Module) error {
 	rawPayload, _ := json.Marshal(module)
-	res, err := m.Client.Do(http.MethodPost, m.basePath(), nil, nil, json.RawMessage(rawPayload))
+	res, err := m.Client.Do(http.MethodPost, m.basePath(orgName), nil, nil, json.RawMessage(rawPayload))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is part of the API client access initiative.

It's possible for a user from the acme org to request a module in the nullstone org.
This update separates the org in the client config from the org in the request URL.
This will be necessary once we move to an access token source model where the access token is retrieved immediatey before API request.

This also adds `find.ModuleDownloadUrl`.