### PR TITLE
Fix nil panic

### DIFF
--- a/find/app.go
+++ b/find/app.go
@@ -41,6 +41,8 @@ func App(cfg api.Config, appName, stackName string) (*types.Application, error) 
 		stack, err := client.StacksByName().Get(stackName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find stack %q: %w", stackName, err)
+		} else if stack == nil {
+			return nil, StackDoesNotExistError{StackName: stackName}
 		}
 		stackId = stack.Id
 	}

--- a/find/missing_errors.go
+++ b/find/missing_errors.go
@@ -1,0 +1,30 @@
+package find
+
+import "fmt"
+
+type AppDoesNotExistError struct{ AppName string }
+
+func (e AppDoesNotExistError) Error() string {
+	return fmt.Sprintf("application %q does not exist", e.AppName)
+}
+
+type StackDoesNotExistError struct{ StackName string }
+
+func (e StackDoesNotExistError) Error() string {
+	return fmt.Sprintf("stack %q does not exist", e.StackName)
+}
+
+type StackIdDoesNotExistError struct{ StackId int64 }
+
+func (e StackIdDoesNotExistError) Error() string {
+	return fmt.Sprintf("stack %d does not exist", e.StackId)
+}
+
+type EnvDoesNotExistError struct {
+	StackName string
+	EnvName   string
+}
+
+func (e EnvDoesNotExistError) Error() string {
+	return fmt.Sprintf("environment %s/%s does not exist", e.StackName, e.EnvName)
+}

--- a/find/stack_app_env.go
+++ b/find/stack_app_env.go
@@ -1,7 +1,6 @@
 package find
 
 import (
-	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
@@ -11,14 +10,14 @@ func StackAppEnv(cfg api.Config, stackName, appName, envName string) (*types.Sta
 	if err != nil {
 		return nil, nil, nil, err
 	} else if app == nil {
-		return nil, nil, nil, fmt.Errorf("application %q does not exist", appName)
+		return nil, nil, nil, AppDoesNotExistError{AppName: appName}
 	}
 
 	if stackName == "" {
 		client := api.Client{Config: cfg}
 		s, err := client.Stacks().Get(app.StackId)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("stack %q does not exist", app.StackId)
+			return nil, nil, nil, StackIdDoesNotExistError{StackId: app.StackId}
 		}
 		stackName = s.Name
 	}
@@ -26,14 +25,14 @@ func StackAppEnv(cfg api.Config, stackName, appName, envName string) (*types.Sta
 	if err != nil {
 		return nil, nil, nil, err
 	} else if stack == nil {
-		return nil, nil, nil, fmt.Errorf("stack %q does not exist", stackName)
+		return nil, nil, nil, StackDoesNotExistError{StackName: stackName}
 	}
 
 	env, err := Env(cfg, stack.Id, envName)
 	if err != nil {
 		return nil, nil, nil, err
 	} else if env == nil {
-		return nil, nil, nil, fmt.Errorf("environment %s/%s does not exist", stack.Name, envName)
+		return nil, nil, nil, EnvDoesNotExistError{StackName: stack.Name, EnvName: envName}
 	}
 
 	return stack, app, env, nil


### PR DESCRIPTION
This fixes a nil panic when a user specifies a `stackName` to search for an app, but the stack doesn't exist.