### PR TITLE
Created method to sort module contract names

### DIFF
--- a/types/module_contract_name.go
+++ b/types/module_contract_name.go
@@ -86,3 +86,61 @@ func matchContractPart(want, got string, optional bool) bool {
 	}
 	return want == got
 }
+
+// CompareModuleContractName provides a comparison of two module contract names for sorting by specificity, then alphabetically
+// This will walk through category, provider, and platform to ensure that "more-specific" contracts appear first
+// A contract with all wildcards is least-specific; a contract with no wildcards is most-specific
+// A backup comparison is made on alphabetic order
+func CompareModuleContractName(a, b ModuleContractName) bool {
+	category := compareContractPart(a.Category, b.Category, false)
+	if category != 0 {
+		return category < 0
+	}
+	subcategory := compareContractPart(a.Subcategory, b.Subcategory, true)
+	if subcategory != 0 {
+		return subcategory < 0
+	}
+	provider := compareContractPart(a.Provider, b.Provider, false)
+	if provider != 0 {
+		return provider < 0
+	}
+	platform := compareContractPart(a.Platform, b.Platform, false)
+	if platform != 0 {
+		return platform < 0
+	}
+	subplatform := compareContractPart(a.Subplatform, b.Subplatform, true)
+	if subplatform != 0 {
+		return subplatform < 0
+	}
+	return false
+}
+
+func compareContractPart(a, b string, optional bool) int {
+	if optional {
+		if a == "" {
+			a = "*"
+		}
+		if b == "" {
+			b = "*"
+		}
+	}
+
+	if a == b {
+		// both * or same value
+		return 0
+	}
+	if a == "*" && b != "*" {
+		// a is less-specific
+		return 1
+	}
+	if a != "*" && b == "*" {
+		// b is less specific
+		return -1
+	}
+	if a < b {
+		// a is before in alphabet
+		return -1
+	}
+	// b is before in alphabet
+	return 1
+}

--- a/types/module_contract_name_test.go
+++ b/types/module_contract_name_test.go
@@ -1,7 +1,9 @@
 package types
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"sort"
 	"testing"
 )
 
@@ -33,4 +35,92 @@ func TestModuleContractName_Match(t *testing.T) {
 			assert.True(t, result)
 		})
 	}
+}
+
+func TestCompareModuleContractName(t *testing.T) {
+	tests := []struct {
+		a        string
+		b        string
+		wantLess bool
+	}{
+		{
+			a:        "app:server/aws/ec2:beanstalk",
+			b:        "app:server/aws/ec2:*",
+			wantLess: true,
+		},
+		{
+			a:        "app:container/aws/ecs:fargate",
+			b:        "app:container/aws/ecs:*",
+			wantLess: true,
+		},
+		{
+			a:        "app:container/aws/ecs:fargate",
+			b:        "app:container/aws/ecs",
+			wantLess: true,
+		},
+		{
+			a:        "app:container/aws/ecs:fargate",
+			b:        "app:container/aws/ecs:*",
+			wantLess: true,
+		},
+		{
+			a:        "app:container/aws/ecs:fargate",
+			b:        "app:container/aws/ecs:ec2",
+			wantLess: false,
+		},
+		{
+			a:        "app:container/aws/ec2",
+			b:        "app:server/aws/ecs",
+			wantLess: true,
+		},
+		{
+			a:        "app:container/aws/k8s",
+			b:        "app:container/gcp/k8s",
+			wantLess: true,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			a, err := ParseModuleContractName(test.a)
+			if err != nil {
+				t.Fatalf("bad contract name (a): %s", err)
+			}
+			b, err := ParseModuleContractName(test.b)
+			if err != nil {
+				t.Fatalf("bad contract name (b): %s", err)
+			}
+			got := CompareModuleContractName(a, b)
+			assert.Equal(t, test.wantLess, got)
+		})
+	}
+}
+
+func TestCompareModuleContractName_Sort(t *testing.T) {
+	all := []string{
+		"app:serverless/aws/lambda:*",
+		"app:server/aws/ec2:*",
+		"app:container/aws/ecs:*",
+		"app:container/gcp/k8s:gke",
+		"app:static-site/aws/s3:*",
+		"app:server/aws/ec2:beanstalk",
+	}
+	want := []string{
+		"app:container/aws/ecs:*",
+		"app:container/gcp/k8s:gke",
+		"app:server/aws/ec2:beanstalk",
+		"app:server/aws/ec2:*",
+		"app:serverless/aws/lambda:*",
+		"app:static-site/aws/s3:*",
+	}
+	got := make([]string, len(all))
+	copy(got, all)
+
+	sort.SliceStable(got, func(i, j int) bool {
+		a, _ := ParseModuleContractName(got[i])
+		b, _ := ParseModuleContractName(got[j])
+		return CompareModuleContractName(a, b)
+	})
+
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
We use `types.ModuleContractName` to register providers for deployment, ssh, logs, and more.

An issue recently emerged where the EC2 provider was being detected instead of the Beanstalk provider.
This happened because the logic loops through the providers to match the contract.
The EC2 contract (`app:server/aws/ec2:*`) technically matches the beanstalk module (`app:server/aws/ec2:beanstalk`).

To resolve this, I created a sorting function that can be used to list the contracts in order from most-specific to least-specific (and falling back to alphabetical).
This will ensure that matching provider will find the most-specific one instead of a random one.