### PR TITLE
B1885 normalization fix

### DIFF
--- a/find/stack_resolver.go
+++ b/find/stack_resolver.go
@@ -30,14 +30,16 @@ func (r *StackResolver) Envs(ctx context.Context) (map[int64]types.Environment, 
 	return r.EnvsById, nil
 }
 
-func (r *StackResolver) ResolveEnv(ctx context.Context, ct types.ConnectionTarget, curEnvId int64) (types.Environment, error) {
+func (r *StackResolver) ResolveEnv(ctx context.Context, ct types.ConnectionTarget) (*types.Environment, error) {
 	if ct.EnvName != "" {
-		return r.ResolveEnvByName(ctx, ct.EnvName)
+		env, err := r.ResolveEnvByName(ctx, ct.EnvName)
+		return &env, err
 	}
 	if ct.EnvId == nil {
-		ct.EnvId = &curEnvId
+		return nil, nil
 	}
-	return r.ResolveEnvById(ctx, *ct.EnvId)
+	env, err := r.ResolveEnvById(ctx, *ct.EnvId)
+	return &env, err
 }
 
 func (r *StackResolver) ResolveEnvByName(ctx context.Context, envName string) (types.Environment, error) {

--- a/find/stack_resolver_test.go
+++ b/find/stack_resolver_test.go
@@ -63,35 +63,27 @@ func TestStackResolver_ResolveEnv(t *testing.T) {
 			StackId: stack1Id,
 			EnvId:   &env3.Id,
 		}
-		got, gotErr := sr.ResolveEnv(context.Background(), ct, env1.Id)
+		got, gotErr := sr.ResolveEnv(context.Background(), ct)
 		assert.ErrorIs(t, gotErr, EnvIdDoesNotExistError{StackName: "primary", EnvId: env3.Id})
-		assert.Equal(t, types.Environment{}, got, "env should be empty")
+		assert.Equal(t, types.Environment{}, *got, "env should be empty")
 	})
 	t.Run("needs loaded first", func(t *testing.T) {
 		ct := types.ConnectionTarget{
 			StackId: stack1Id,
 			EnvId:   &env1.Id,
 		}
-		got, err := sr.ResolveEnv(context.Background(), ct, env1.Id)
+		got, err := sr.ResolveEnv(context.Background(), ct)
 		assert.NoError(t, err)
-		assert.Equal(t, env1, got, "should resolve env1")
+		assert.Equal(t, env1, *got, "should resolve env1")
 	})
 	t.Run("already loaded", func(t *testing.T) {
 		ct := types.ConnectionTarget{
 			StackId: stack1Id,
 			EnvId:   &env1.Id,
 		}
-		got, err := sr.ResolveEnv(context.Background(), ct, env1.Id)
+		got, err := sr.ResolveEnv(context.Background(), ct)
 		assert.NoError(t, err)
-		assert.Equal(t, env1, got, "should resolve env1")
-	})
-	t.Run("loads current env", func(t *testing.T) {
-		ct := types.ConnectionTarget{
-			StackId: stack1Id,
-		}
-		got, err := sr.ResolveEnv(context.Background(), ct, env1.Id)
-		assert.NoError(t, err)
-		assert.Equal(t, env1, got, "should resolve env1")
+		assert.Equal(t, env1, *got, "should resolve env1")
 	})
 }
 


### PR DESCRIPTION
This reworks how connections are normalized within the resolver. We currently have a bug where the current state of previews-shared and shared blocks is not observed.

Imagine that you have launched a preview environment and during first launch, the mysql db block was marked as shared.
You then destroy the env, mark the block as NOT shared, and relaunch.

In our current code, the connections to the mysql block will remain shared. This is because the capability connection that has been saved in the db says that the connection points to the shared env. This can never be "undone" in our current code.

-----------------

This PR fixes that scenario so that if you change your previews-shared or shared blocks settings, the connections will be updated accordingly. In the scenario above, we don't care what the previous configuration was, we will calculate the env for the connection from scratch. In the code for this PR, we are only doing this for preview environments. For pipeline environments, we don't make any changes but rather just simply utilize what has been set.