### PR TITLE
Added IntentWorkflow.WatchGet

### DIFF
--- a/intent_workflows.go
+++ b/intent_workflows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"gopkg.in/nullstone-io/go-api-client.v0/ws"
 	"net/http"
 )
 
@@ -34,4 +35,12 @@ func (s IntentWorkflows) Get(ctx context.Context, stackId, intentWorkflowId int6
 		return nil, err
 	}
 	return response.ReadJsonPtr[types.IntentWorkflow](res)
+}
+
+func (s IntentWorkflows) WatchGet(ctx context.Context, stackId, intentWorkflowId int64, retryFn ws.StreamerRetryFunc) (*types.IntentWorkflow, <-chan types.StreamObject[types.IntentWorkflowUpdate], error) {
+	endpoint, headers, err := s.Client.Config.ConstructWsEndpoint(ctx, s.path(stackId, intentWorkflowId))
+	if err != nil {
+		return nil, nil, err
+	}
+	return ws.StreamObject[types.IntentWorkflow, types.IntentWorkflowUpdate](ctx, endpoint, headers, retryFn)
 }

--- a/runs/create.go
+++ b/runs/create.go
@@ -16,9 +16,9 @@ func Create(ctx context.Context, cfg api.Config, workspace types.Workspace, comm
 	}
 
 	client := api.Client{Config: cfg}
-	newRun, err := client.Runs().Create(ctx, workspace.StackId, workspace.Uid, input)
+	result, err := client.Runs().Create(ctx, workspace.StackId, workspace.Uid, input)
 	if err != nil {
 		return nil, fmt.Errorf("error creating run: %w", err)
 	}
-	return newRun, nil
+	return result, nil
 }

--- a/types/intent_workflow.go
+++ b/types/intent_workflow.go
@@ -54,3 +54,12 @@ type IntentWorkflow struct {
 	// This is not included when Listing many workflows
 	WorkspaceWorkflows []WorkspaceWorkflow `json:"workspaceWorkflows"`
 }
+
+type IntentWorkflowUpdate struct {
+	Id                 int64               `json:"id"`
+	Status             *string             `json:"status,omitempty"`
+	StatusAt           *time.Time          `json:"statusAt,omitempty"`
+	StatusMessage      *string             `json:"statusMessage,omitempty"`
+	WorkspaceWorkflows []WorkspaceWorkflow `json:"workspaceWorkflows,omitempty"`
+	RootWorkflowIds    []int64             `json:"rootWorkflowIds,omitempty"`
+}

--- a/types/stream_object.go
+++ b/types/stream_object.go
@@ -1,0 +1,6 @@
+package types
+
+type StreamObject[T any] struct {
+	Object T
+	Err    error
+}

--- a/types/workspace_workflow.go
+++ b/types/workspace_workflow.go
@@ -28,6 +28,18 @@ const (
 	WorkspaceWorkflowStatusCancelled WorkspaceWorkflowStatus = "cancelled"
 )
 
+func IsTerminalWorkspaceWorkflow(status WorkspaceWorkflowStatus) bool {
+	switch status {
+	case WorkspaceWorkflowStatusCompleted:
+		return true
+	case WorkspaceWorkflowStatusFailed:
+		return true
+	case WorkspaceWorkflowStatusCancelled:
+		return true
+	}
+	return false
+}
+
 type WorkspaceWorkflow struct {
 	IdModel
 	FriendlyAction string                  `json:"friendlyAction"`

--- a/types/workspace_workflow.go
+++ b/types/workspace_workflow.go
@@ -6,23 +6,45 @@ import (
 	"time"
 )
 
+type WorkspaceWorkflowStatus string
+
+const (
+	// WorkspaceWorkflowStatusInit indicates the workflows was added to the database
+	// These should be excluded from listing to a user
+	WorkspaceWorkflowStatusInit WorkspaceWorkflowStatus = "init"
+	// WorkspaceWorkflowStatusQueued indicates the workflow is ready to execute; waiting on a worker to execute
+	WorkspaceWorkflowStatusQueued WorkspaceWorkflowStatus = "queued"
+	// WorkspaceWorkflowStatusAwaiting indicates that this workflow is waiting for other dependencies to finish before it can run
+	WorkspaceWorkflowStatusAwaiting WorkspaceWorkflowStatus = "awaiting-dependencies"
+	// WorkspaceWorkflowStatusNeedsApproval indicates an execution inside this workflow is waiting for user approval
+	WorkspaceWorkflowStatusNeedsApproval WorkspaceWorkflowStatus = "needs-approval"
+	// WorkspaceWorkflowStatusRunning indicates the workflow is currently running
+	WorkspaceWorkflowStatusRunning WorkspaceWorkflowStatus = "running"
+	// WorkspaceWorkflowStatusCompleted indicates the workflow completed successfully
+	WorkspaceWorkflowStatusCompleted WorkspaceWorkflowStatus = "completed"
+	// WorkspaceWorkflowStatusFailed indicates the workflow failed to complete
+	WorkspaceWorkflowStatusFailed WorkspaceWorkflowStatus = "failed"
+	// WorkspaceWorkflowStatusCancelled indicates the workflow was cancelled
+	WorkspaceWorkflowStatusCancelled WorkspaceWorkflowStatus = "cancelled"
+)
+
 type WorkspaceWorkflow struct {
 	IdModel
-	FriendlyAction string          `json:"friendlyAction"`
-	Actions        []string        `json:"actions"`
-	OrgName        string          `json:"orgName"`
-	WorkspaceUid   uuid.UUID       `json:"workspaceUid"`
-	StackId        int64           `json:"stackId"`
-	StackName      string          `json:"stackName"`
-	BlockId        int64           `json:"blockId"`
-	BlockName      string          `json:"blockName"`
-	EnvId          int64           `json:"envId"`
-	EnvName        string          `json:"envName"`
-	Status         string          `json:"status"`
-	StatusMessage  string          `json:"statusMessage"`
-	StatusAt       time.Time       `json:"statusAt"`
-	CommitInfo     CommitInfo      `json:"commitInfo"`
-	Trigger        ExternalTrigger `json:"trigger"`
+	FriendlyAction string                  `json:"friendlyAction"`
+	Actions        []string                `json:"actions"`
+	OrgName        string                  `json:"orgName"`
+	WorkspaceUid   uuid.UUID               `json:"workspaceUid"`
+	StackId        int64                   `json:"stackId"`
+	StackName      string                  `json:"stackName"`
+	BlockId        int64                   `json:"blockId"`
+	BlockName      string                  `json:"blockName"`
+	EnvId          int64                   `json:"envId"`
+	EnvName        string                  `json:"envName"`
+	Status         WorkspaceWorkflowStatus `json:"status"`
+	StatusMessage  string                  `json:"statusMessage"`
+	StatusAt       time.Time               `json:"statusAt"`
+	CommitInfo     CommitInfo              `json:"commitInfo"`
+	Trigger        ExternalTrigger         `json:"trigger"`
 
 	// IntentWorkflowOrder is used to sort connections by order of dependencies
 	// Roots of the dependency tree will have a lower order number
@@ -47,12 +69,12 @@ type WorkspaceWorkflow struct {
 }
 
 type WorkspaceWorkflowUpdate struct {
-	Id             int64      `json:"id"`
-	FriendlyAction *string    `json:"friendlyAction"`
-	Actions        []string   `json:"actions,omitempty"`
-	Status         *string    `json:"status,omitempty"`
-	StatusAt       *time.Time `json:"statusAt,omitempty"`
-	StatusMessage  *string    `json:"statusMessage,omitempty"`
+	Id             int64                    `json:"id"`
+	FriendlyAction *string                  `json:"friendlyAction"`
+	Actions        []string                 `json:"actions,omitempty"`
+	Status         *WorkspaceWorkflowStatus `json:"status,omitempty"`
+	StatusAt       *time.Time               `json:"statusAt,omitempty"`
+	StatusMessage  *string                  `json:"statusMessage,omitempty"`
 	// DependencyWorkflows is not guaranteed to be a full set of all dependencies
 	// Instead, each item in this slice should be seen as "create me" or "update me"
 	DependencyWorkflows []WorkspaceWorkflow `json:"dependencyWorkflows,omitempty"`

--- a/types/workspace_workflow.go
+++ b/types/workspace_workflow.go
@@ -2,27 +2,39 @@ package types
 
 import (
 	"github.com/google/uuid"
+	"slices"
 	"time"
 )
 
 type WorkspaceWorkflow struct {
 	IdModel
-	FriendlyAction   string          `json:"friendlyAction"`
-	Actions          []string        `json:"actions"`
-	OrgName          string          `json:"orgName"`
-	WorkspaceUid     uuid.UUID       `json:"workspaceUid"`
-	StackId          int64           `json:"stackId"`
-	StackName        string          `json:"stackName"`
-	BlockId          int64           `json:"blockId"`
-	BlockName        string          `json:"blockName"`
-	EnvId            int64           `json:"envId"`
-	EnvName          string          `json:"envName"`
-	Status           string          `json:"status"`
-	StatusMessage    string          `json:"statusMessage"`
-	StatusAt         time.Time       `json:"statusAt"`
-	CommitInfo       CommitInfo      `json:"commitInfo"`
-	Trigger          ExternalTrigger `json:"trigger"`
-	IntentWorkflowId int64           `json:"intentWorkflowId"`
+	FriendlyAction string          `json:"friendlyAction"`
+	Actions        []string        `json:"actions"`
+	OrgName        string          `json:"orgName"`
+	WorkspaceUid   uuid.UUID       `json:"workspaceUid"`
+	StackId        int64           `json:"stackId"`
+	StackName      string          `json:"stackName"`
+	BlockId        int64           `json:"blockId"`
+	BlockName      string          `json:"blockName"`
+	EnvId          int64           `json:"envId"`
+	EnvName        string          `json:"envName"`
+	Status         string          `json:"status"`
+	StatusMessage  string          `json:"statusMessage"`
+	StatusAt       time.Time       `json:"statusAt"`
+	CommitInfo     CommitInfo      `json:"commitInfo"`
+	Trigger        ExternalTrigger `json:"trigger"`
+
+	// IntentWorkflowOrder is used to sort connections by order of dependencies
+	// Roots of the dependency tree will have a lower order number
+	// The order number is calculated by walking through the tree and incrementing a counter using in-order traversal
+	IntentWorkflowOrder int `json:"intentWorkflowOrder"`
+	// IntentWorkflowId points to the IntentWorkflow that collects a set of workspace workflows into a single execution
+	IntentWorkflowId int64 `json:"intentWorkflowId"`
+
+	// PreviousWorkflowId is the ID of the workspace workflow that was created before this workflow within this workspace
+	PreviousWorkflowId int64 `json:"previousWorkflowId"`
+	// NextWorkflowId is the ID of the workspace workflow that was created after this workflow within this workspace
+	NextWorkflowId int64 `json:"nextWorkflowId"`
 
 	// DependencyWorkflowIds is a list of models.WorkspaceWorkflow referring to other dependencies
 	// This contains all immediate *and* transitive dependencies
@@ -32,4 +44,65 @@ type WorkspaceWorkflow struct {
 	IntentWorkflow   *IntentWorkflow   `json:"intentWorkflow,omitempty"`
 	IacSyncWorkspace *IacSyncWorkspace `json:"iacSyncWorkspace,omitempty"`
 	Run              *Run              `json:"run,omitempty"`
+}
+
+type WorkspaceWorkflowUpdate struct {
+	Id             int64      `json:"id"`
+	FriendlyAction *string    `json:"friendlyAction"`
+	Actions        []string   `json:"actions,omitempty"`
+	Status         *string    `json:"status,omitempty"`
+	StatusAt       *time.Time `json:"statusAt,omitempty"`
+	StatusMessage  *string    `json:"statusMessage,omitempty"`
+	// DependencyWorkflows is not guaranteed to be a full set of all dependencies
+	// Instead, each item in this slice should be seen as "create me" or "update me"
+	DependencyWorkflows []WorkspaceWorkflow `json:"dependencyWorkflows,omitempty"`
+	// NextWorkflowId is the ID of the workspace workflow that was created after this workflow
+	NextWorkflowId      *int64  `json:"nextWorkflowId,omitempty"`
+	IntentWorkflowOrder *int    `json:"intentWorkflowOrder,omitempty"`
+	Run                 *Run    `json:"run,omitempty"`
+	Build               *Build  `json:"build,omitempty"`
+	Deploy              *Deploy `json:"deploy,omitempty"`
+}
+
+func (u WorkspaceWorkflowUpdate) ApplyTo(ww WorkspaceWorkflow) WorkspaceWorkflow {
+	if ww.Id != u.Id {
+		return ww
+	}
+	if u.FriendlyAction != nil {
+		ww.FriendlyAction = *u.FriendlyAction
+	}
+	if u.Actions != nil {
+		ww.Actions = u.Actions
+	}
+	if u.Status != nil {
+		ww.Status = *u.Status
+	}
+	if u.StatusAt != nil {
+		ww.StatusAt = *u.StatusAt
+	}
+	if u.StatusMessage != nil {
+		ww.StatusMessage = *u.StatusMessage
+	}
+	if u.NextWorkflowId != nil {
+		ww.NextWorkflowId = *u.NextWorkflowId
+	}
+	if u.IntentWorkflowOrder != nil {
+		ww.IntentWorkflowOrder = *u.IntentWorkflowOrder
+	}
+	if u.Run != nil {
+		ww.Run = u.Run
+	}
+	if u.DependencyWorkflows != nil {
+		for _, dw := range u.DependencyWorkflows {
+			existingIndex := slices.IndexFunc(ww.DependencyWorkflows, func(w WorkspaceWorkflow) bool {
+				return w.Id == dw.Id
+			})
+			if existingIndex > -1 {
+				ww.DependencyWorkflows[existingIndex] = dw
+			} else {
+				ww.DependencyWorkflows = append(ww.DependencyWorkflows, dw)
+			}
+		}
+	}
+	return ww
 }

--- a/types/workspace_workflow_activities.go
+++ b/types/workspace_workflow_activities.go
@@ -1,0 +1,7 @@
+package types
+
+type WorkspaceWorkflowActivities struct {
+	WorkspaceWorkflowId int64   `json:"workspaceWorkflowId"`
+	Build               *Build  `json:"build"`
+	Deploy              *Deploy `json:"deploy"`
+}

--- a/workspace_workflows.go
+++ b/workspace_workflows.go
@@ -24,6 +24,10 @@ func (ww WorkspaceWorkflows) path(stackId, blockId, envId, workspaceWorkflowId i
 	return fmt.Sprintf("/orgs/%s/stacks/%d/blocks/%d/envs/%d/workspace_workflows/%d", ww.Client.Config.OrgName, stackId, blockId, envId, workspaceWorkflowId)
 }
 
+func (ww WorkspaceWorkflows) activitiesPath(stackId, blockId, envId, workspaceWorkflowId int64) string {
+	return fmt.Sprintf("/orgs/%s/stacks/%d/blocks/%d/envs/%d/workspace_workflow_activities/%d", ww.Client.Config.OrgName, stackId, blockId, envId, workspaceWorkflowId)
+}
+
 func (ww WorkspaceWorkflows) List(ctx context.Context, stackId, blockId, envId int64, page, perPage int) ([]types.WorkspaceWorkflow, error) {
 	q := url.Values{}
 	if page > 0 {
@@ -45,6 +49,14 @@ func (ww WorkspaceWorkflows) Get(ctx context.Context, stackId, blockId, envId, w
 		return nil, err
 	}
 	return response.ReadJsonPtr[types.WorkspaceWorkflow](res)
+}
+
+func (ww WorkspaceWorkflows) GetActivities(ctx context.Context, stackId, blockId, envId, workspaceWorkflowId int64) (*types.WorkspaceWorkflowActivities, error) {
+	res, err := ww.Client.Do(ctx, http.MethodGet, ww.activitiesPath(stackId, blockId, envId, workspaceWorkflowId), nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return response.ReadJsonPtr[types.WorkspaceWorkflowActivities](res)
 }
 
 type CreateWorkspaceWorkflowInput struct {

--- a/workspace_workflows.go
+++ b/workspace_workflows.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"gopkg.in/nullstone-io/go-api-client.v0/ws"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -57,6 +58,14 @@ func (ww WorkspaceWorkflows) GetActivities(ctx context.Context, stackId, blockId
 		return nil, err
 	}
 	return response.ReadJsonPtr[types.WorkspaceWorkflowActivities](res)
+}
+
+func (ww WorkspaceWorkflows) WatchGet(ctx context.Context, stackId, blockId, envId, workspaceWorkflowId int64, retryFn ws.StreamerRetryFunc) (*types.WorkspaceWorkflow, <-chan types.StreamObject[types.WorkspaceWorkflowUpdate], error) {
+	endpoint, headers, err := ww.Client.Config.ConstructWsEndpoint(ctx, ww.path(stackId, blockId, envId, workspaceWorkflowId))
+	if err != nil {
+		return nil, nil, err
+	}
+	return ws.StreamObject[types.WorkspaceWorkflow, types.WorkspaceWorkflowUpdate](ctx, endpoint, headers, retryFn)
 }
 
 type CreateWorkspaceWorkflowInput struct {

--- a/ws/stream_object.go
+++ b/ws/stream_object.go
@@ -1,0 +1,62 @@
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"net/http"
+)
+
+// StreamObject performs a websocket request against an endpoint
+// This blocks until the initial "hydrate" response containing the full object as it currently exists
+// The returned channel will emit update objects as the server streams updates
+func StreamObject[T any, TUpdate any](ctx context.Context, endpoint string, headers http.Header, retryFn StreamerRetryFunc) (*T, <-chan types.StreamObject[TUpdate], error) {
+	s := Streamer{
+		Endpoint: endpoint,
+		Headers:  headers,
+		RetryFn:  retryFn,
+	}
+	rawMsgs := s.Stream(ctx)
+
+	var initial T
+	if msg, err := readStreamMessage(rawMsgs); err != nil {
+		return nil, nil, err
+	} else if msg == nil {
+		return nil, nil, nil
+	} else if msg.Context != "hydrate" {
+		return nil, nil, fmt.Errorf("did not receive initial object from stream")
+	} else if err := json.Unmarshal([]byte(msg.Content), &initial); err != nil {
+		return nil, nil, fmt.Errorf("error reading initial object from stream: %w", err)
+	}
+
+	ch := make(chan types.StreamObject[TUpdate])
+	go func() {
+		defer close(ch)
+		for {
+			if msg, err := readStreamMessage(rawMsgs); err != nil {
+				ch <- types.StreamObject[TUpdate]{Err: err}
+			} else if msg == nil {
+				return
+			} else {
+				var so types.StreamObject[TUpdate]
+				so.Err = json.Unmarshal([]byte(msg.Content), &so.Object)
+				ch <- so
+			}
+		}
+	}()
+
+	return &initial, ch, nil
+}
+
+func readStreamMessage(ch <-chan []byte) (*types.Message, error) {
+	raw, ok := <-ch
+	if !ok {
+		return nil, nil
+	}
+	var msg types.Message
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return nil, fmt.Errorf("error reading message from stream: %w", err)
+	}
+	return &msg, nil
+}

--- a/ws/stream_object_test.go
+++ b/ws/stream_object_test.go
@@ -1,0 +1,154 @@
+package ws
+
+import (
+	"context"
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStreamObject(t *testing.T) {
+	type hydrateObject struct {
+		Id     int64  `json:"id"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}
+	type updateObject struct {
+		Id     int64  `json:"id"`
+		Status string `json:"status"`
+	}
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1204,
+		WriteBufferSize: 1204,
+		CheckOrigin:     func(r *http.Request) bool { return true },
+	}
+
+	tests := []struct {
+		name                         string
+		messages                     []types.Message
+		closeServerAfterTestMessages bool
+		clientTimeout                time.Duration
+		wantInitial                  hydrateObject
+		wantUpdates                  []types.StreamObject[updateObject]
+	}{
+		{
+			name: "send hydrate and 2 updates",
+			messages: []types.Message{
+				{
+					Context: "hydrate",
+					Content: `{"id":1,"name":"test1","status":"calculating"}`,
+				},
+				{
+					Context: "updated",
+					Content: `{"id":1,"status":"running"}`,
+				},
+				{
+					Context: "updated",
+					Content: `{"id":1,"status":"completed"}`,
+				},
+			},
+			closeServerAfterTestMessages: true,
+			wantInitial: hydrateObject{
+				Id:     1,
+				Name:   "test1",
+				Status: "calculating",
+			},
+			wantUpdates: []types.StreamObject[updateObject]{
+				{
+					Object: updateObject{
+						Id:     1,
+						Status: "running",
+					},
+				},
+				{
+					Object: updateObject{
+						Id:     1,
+						Status: "completed",
+					},
+				},
+			},
+		},
+		{
+			name: "send hydrate, client cancels",
+			messages: []types.Message{
+				{
+					Context: "hydrate",
+					Content: `{"id":1,"name":"test1","status":"calculating"}`,
+				},
+			},
+			clientTimeout: 10 * time.Millisecond,
+			wantInitial: hydrateObject{
+				Id:     1,
+				Name:   "test1",
+				Status: "calculating",
+			},
+			wantUpdates: []types.StreamObject[updateObject]{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(100*time.Millisecond))
+			defer cancel()
+			if test.clientTimeout > 0 {
+				// This simulates a user cancelling the stream from the client side
+				// This verifies that the
+				var cancel func()
+				ctx, cancel = context.WithTimeout(ctx, test.clientTimeout)
+				defer cancel()
+			}
+
+			router := mux.NewRouter()
+			router.Methods(http.MethodGet).
+				Path("/endpoint").
+				HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					conn, err := upgrader.Upgrade(w, r, nil)
+					if err != nil {
+						http.Error(w, fmt.Sprintf("error upgrading websocket: %s", err), http.StatusInternalServerError)
+						return
+					}
+					require.NotNil(t, conn, "websocket connection")
+					defer conn.Close()
+
+					for _, msg := range test.messages {
+						conn.WriteJSON(msg)
+					}
+					if test.closeServerAfterTestMessages {
+						closeData := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "end of transmission")
+						conn.WriteMessage(websocket.CloseMessage, closeData)
+					}
+
+					msgType, data, err := conn.ReadMessage()
+					log.Println(msgType, data, err)
+				})
+			server := httptest.NewServer(router)
+
+			u, err := url.Parse(server.URL)
+			require.NoError(t, err, "parse server url")
+			u.Path = "/endpoint"
+			u.Scheme = strings.Replace(u.Scheme, "http", "ws", 1)
+			gotInitial, ch, err := StreamObject[hydrateObject, updateObject](ctx, u.String(), http.Header{}, RetryInfinite(time.Millisecond))
+			require.NoError(t, err, "unexpected error")
+			require.NotNil(t, ch, "stream channel")
+			if assert.NotNil(t, gotInitial, "hydrate object not nil") {
+				assert.Equal(t, test.wantInitial, *gotInitial, "hydrate object")
+			}
+			gotUpdates := make([]types.StreamObject[updateObject], 0)
+			for update := range ch {
+				gotUpdates = append(gotUpdates, update)
+			}
+			assert.Equal(t, test.wantUpdates, gotUpdates, "updates")
+		})
+	}
+}


### PR DESCRIPTION
Now that Runs.Create, EnvRuns.Create, and Deploys.Create returns an IntentWorkflow, a Build, Deploy, or Run doesn't exist at the completion of the API response. 

This adds `IntentWorkflow.WatchGet` to monitor the IntentWorkflow. We can retrieve the Build, Deploy, or Run once the IntentWorkflow transitions to "running".