### PR TITLE
Exposed ExpiresAtThreshold to be configurable on auth.RunnerAccessTokenSource

### DIFF
--- a/auth/jwt_token_expires_cache.go
+++ b/auth/jwt_token_expires_cache.go
@@ -16,8 +16,8 @@ var (
 // Every time Refresh() is called, this cache will only acquire a new access token if:
 // - access token has not been retrieved yet
 // - the access token has expired or close to expiring
-// ExpiresAtThreshold is a duration to configure a token expired before it's expired
-// A token is considered expired if `now() + ExpiresAtThreshold > Token.ExpiresAt`
+// ExpiresAtThreshold is a duration to configure a token refresh before it's expired
+// A token is considered expired if `time.Now() + ExpiresAtThreshold > Token.ExpiresAt`
 // If ExpiresAtThreshold = 0, will use default of 1s
 type JwtTokenExpiresCache struct {
 	Token              *jwt.Token

--- a/auth/runner.go
+++ b/auth/runner.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/cristalhq/jwt/v3"
+	"time"
 )
 
-func NewRunner(ctx context.Context, orgName string, store RunnerKeyStore) (*Runner, error) {
+func NewRunner(ctx context.Context, orgName string, store RunnerKeyStore, expiresAtThreshold time.Duration) (*Runner, error) {
 	runnerKey, err2 := store.GetOrCreate(ctx, orgName)
 	if err2 != nil {
 		return nil, fmt.Errorf("error retrieving or creating runner key: %w", err2)
@@ -16,8 +17,10 @@ func NewRunner(ctx context.Context, orgName string, store RunnerKeyStore) (*Runn
 	}
 
 	return &Runner{
-		RunnerKey:     runnerKey,
-		JwtTokenCache: &JwtTokenExpiresCache{},
+		RunnerKey: runnerKey,
+		JwtTokenCache: &JwtTokenExpiresCache{
+			ExpiresAtThreshold: expiresAtThreshold,
+		},
 	}, nil
 }
 

--- a/auth/runner_access_token_source.go
+++ b/auth/runner_access_token_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 )
 
 // RunnerAccessTokenSource coordinates a trust relationship between nullstone auth server and a runner
@@ -12,6 +13,10 @@ import (
 type RunnerAccessTokenSource struct {
 	AuthServer     RunnerAccessTokenGetter
 	RunnerKeyStore RunnerKeyStore
+	// ExpiresAtThreshold is a duration to configure a token refresh before it's expired
+	// See JwtTokenExpiresCache
+	// By default, this is "0" which indicates the default of 1s
+	ExpiresAtThreshold time.Duration
 
 	cache map[string]*Runner
 	mu    sync.Mutex
@@ -46,7 +51,7 @@ func (s *RunnerAccessTokenSource) getOrInitialize(ctx context.Context, orgName s
 		return runner, nil
 	}
 
-	runner, err := NewRunner(ctx, orgName, s.RunnerKeyStore)
+	runner, err := NewRunner(ctx, orgName, s.RunnerKeyStore, s.ExpiresAtThreshold)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize runner: %w", err)
 	}


### PR DESCRIPTION
See https://app.ora.pm/p/280750?c=13165242

This will allow us to configure a higher threshold for refreshing a runner access token.