### PR TITLE
F/2047/repo type

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -23,8 +23,8 @@ type Block struct {
 	Name                string                      `json:"name"`
 	IsShared            bool                        `json:"isShared"`
 	OwningRepo          string                      `json:"owningRepo"`
-	Repo                string                      `json:"repo"`
-	Framework           string                      `json:"framework"`
+	Repo                string                      `json:"repo,omitempty"`
+	Framework           string                      `json:"framework,omitempty"`
 	DnsName             string                      `json:"dnsName,omitempty"`
 	ModuleSource        string                      `json:"moduleSource"`
 	ModuleSourceVersion string                      `json:"moduleSourceVersion"`

--- a/types/commit_info.go
+++ b/types/commit_info.go
@@ -13,13 +13,9 @@ const (
 type CommitInfo struct {
 	Type        string `json:"type"`
 	VcsProvider string `json:"vcsProvider"`
-	RepoOwner   string `json:"repoOwner"`
-	RepoName    string `json:"repoName"`
-	// Repo is `RepoOwner/RepoName`
-	Repo       string `json:"repo"`
-	RepoUrl    string `json:"repoUrl"`
-	BranchName string `json:"branchName"`
-	CommitSha  string `json:"commitSha"`
+	Repo        Repo   `json:"repo"`
+	BranchName  string `json:"branchName"`
+	CommitSha   string `json:"commitSha"`
 	// CommitUrl is the HTML URL to browse this commit
 	CommitUrl     string `json:"commitUrl"`
 	CommitMessage string `json:"commitMessage"`

--- a/types/commit_info.go
+++ b/types/commit_info.go
@@ -11,22 +11,25 @@ const (
 )
 
 type CommitInfo struct {
-	Type        string `json:"type"`
+	Type string `json:"type"`
+
+	// VcsProvider
+	// Deprecated - Use Repo.Provider
 	VcsProvider string `json:"vcsProvider"`
 
 	// Repository contains information about the commit repository (e.g. host, owner, name)
 	Repository Repo `json:"repository"`
 	// RepoOwner
-	// Deprecated - Use Repository
+	// Deprecated - Use Repo.Owner
 	RepoOwner string `json:"repoOwner"`
 	// RepoName
-	// Deprecated - Use Repository
+	// Deprecated - Use Repo.Name
 	RepoName string `json:"repoName"`
 	// Repo is `RepoOwner/RepoName`
-	// Deprecated - Use Repository
+	// Deprecated - Use Repo.Owner/Repo.Name
 	Repo string `json:"repo"`
 	// RepoUrl
-	// Deprecated - Use Repository
+	// Deprecated - Use Repo.Url
 	RepoUrl string `json:"repoUrl"`
 
 	BranchName string `json:"branchName"`

--- a/types/commit_info.go
+++ b/types/commit_info.go
@@ -13,13 +13,28 @@ const (
 type CommitInfo struct {
 	Type        string `json:"type"`
 	VcsProvider string `json:"vcsProvider"`
-	Repo        Repo   `json:"repo"`
-	BranchName  string `json:"branchName"`
-	CommitSha   string `json:"commitSha"`
+
+	// Repository contains information about the commit repository (e.g. host, owner, name)
+	Repository Repo `json:"repository"`
+	// RepoOwner
+	// Deprecated - Use Repository
+	RepoOwner string `json:"repoOwner"`
+	// RepoName
+	// Deprecated - Use Repository
+	RepoName string `json:"repoName"`
+	// Repo is `RepoOwner/RepoName`
+	// Deprecated - Use Repository
+	Repo string `json:"repo"`
+	// RepoUrl
+	// Deprecated - Use Repository
+	RepoUrl string `json:"repoUrl"`
+
+	BranchName string `json:"branchName"`
+
+	CommitSha string `json:"commitSha"`
 	// CommitUrl is the HTML URL to browse this commit
 	CommitUrl     string `json:"commitUrl"`
 	CommitMessage string `json:"commitMessage"`
-
 	// CommitUserId is the user id for the VCS user that created the commit
 	// This is not guaranteed to be the same as the AuthorId
 	// When using the GitHub UI to merge, the CommitUsername is actually `web-flow`

--- a/types/repo.go
+++ b/types/repo.go
@@ -38,6 +38,7 @@ func RepoFromUrl(repoUrl string) (Repo, error) {
 			Host:  host,
 			Owner: repoTokens[0],
 			Name:  repoTokens[1],
+			Url:   repoUri.String(),
 		}, nil
 	}
 
@@ -48,6 +49,7 @@ func RepoFromUrl(repoUrl string) (Repo, error) {
 			Host:  DefaultRepoHost,
 			Owner: repoTokens[0],
 			Name:  repoTokens[1],
+			Url:   repoUri.String(),
 		}, nil
 	case 3:
 		// <repo-host>/<repo-owner>/<repo-name>
@@ -55,6 +57,7 @@ func RepoFromUrl(repoUrl string) (Repo, error) {
 			Host:  repoTokens[0],
 			Owner: repoTokens[1],
 			Name:  repoTokens[2],
+			Url:   repoUri.String(),
 		}, nil
 	default:
 		return Repo{}, fmt.Errorf("invalid repository url %q: must be [<repo-host>/]<repo-owner>/<repo-name>", repoUrl)

--- a/types/repo.go
+++ b/types/repo.go
@@ -7,14 +7,19 @@ import (
 )
 
 const (
+	RepoProviderGithub = "github"
+)
+
+const (
 	DefaultRepoHost = "github.com"
 )
 
 type Repo struct {
-	Host  string `json:"host"`
-	Owner string `json:"owner"`
-	Name  string `json:"name"`
-	Url   string `json:"url"`
+	Provider string `json:"provider"`
+	Host     string `json:"host"`
+	Owner    string `json:"owner"`
+	Name     string `json:"name"`
+	Url      string `json:"url"`
 }
 
 func RepoFromUrl(repoUrl string) (Repo, error) {

--- a/types/repo.go
+++ b/types/repo.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	DefaultRepoHost = "github.com"
+)
+
+type Repo struct {
+	Host  string `json:"host"`
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
+	Url   string `json:"url"`
+}
+
+func RepoFromUrl(repoUrl string) (Repo, error) {
+	repoUri, err := url.Parse(repoUrl)
+	if err != nil {
+		return Repo{}, fmt.Errorf("invalid repository url %q: %s", repoUrl, err)
+	}
+
+	repoTokens := strings.SplitN(strings.TrimPrefix(repoUri.Path, "/"), "/", 3)
+	if host := repoUri.Host; host != "" {
+		// <scheme>://<repo-host>/<repo-owner>/<repo-name>
+		if len(repoTokens) != 2 {
+			return Repo{}, fmt.Errorf("invalid repository url %q: must be [<repo-host>/]<repo-owner>/<repo-name>", repoUrl)
+		}
+		return Repo{
+			Host:  host,
+			Owner: repoTokens[0],
+			Name:  repoTokens[1],
+		}, nil
+	}
+
+	switch len(repoTokens) {
+	case 2:
+		// <repo-owner>/<repo-name>
+		return Repo{
+			Host:  DefaultRepoHost,
+			Owner: repoTokens[0],
+			Name:  repoTokens[1],
+		}, nil
+	case 3:
+		// <repo-host>/<repo-owner>/<repo-name>
+		return Repo{
+			Host:  repoTokens[0],
+			Owner: repoTokens[1],
+			Name:  repoTokens[2],
+		}, nil
+	default:
+		return Repo{}, fmt.Errorf("invalid repository url %q: must be [<repo-host>/]<repo-owner>/<repo-name>", repoUrl)
+	}
+}

--- a/types/repo_info.go
+++ b/types/repo_info.go
@@ -2,7 +2,7 @@ package types
 
 type RepoInfo struct {
 	Repo `json:",inline"`
-	
+
 	IsPrivate     bool   `json:"isPrivate"`
 	Language      string `json:"language"`
 	DefaultBranch string `json:"defaultBranch"`

--- a/types/repo_info.go
+++ b/types/repo_info.go
@@ -1,0 +1,9 @@
+package types
+
+type RepoInfo struct {
+	Repo `json:",inline"`
+	
+	IsPrivate     bool   `json:"isPrivate"`
+	Language      string `json:"language"`
+	DefaultBranch string `json:"defaultBranch"`
+}


### PR DESCRIPTION
- Block.Repo, Block.Framework are omitted if empty. If not, this causes issues with creating apps
- Add `CommitInfo.Repository` to hold the repo identification (i.e. provider, host, owner, name, url)
- Added `types.RepoInfo` which holds `Repo` *and* `IsPrivate`, `Language`, `DefaultBranch`