### PR TITLE
Dev/fix iac diffs

### DIFF
--- a/types/connection_target.go
+++ b/types/connection_target.go
@@ -93,17 +93,16 @@ func isConnectionTargetEqual(target1 *ConnectionTarget, target2 *ConnectionTarge
 	if target2 == nil {
 		return false
 	}
-	var envId1, envId2 int64
-	if target1.EnvId != nil {
-		envId1 = *target1.EnvId
-	}
-	if target2.EnvId != nil {
-		envId2 = *target2.EnvId
-	}
 	return target1.StackId == target2.StackId &&
 		target1.StackName == target2.StackName &&
 		target1.BlockId == target2.BlockId &&
 		target1.BlockName == target2.BlockName &&
-		envId1 == envId2 &&
-		target1.EnvName == target2.EnvName
+		isConnectionTargetEnvEqual(*target1, *target2)
+}
+
+func isConnectionTargetEnvEqual(t1 ConnectionTarget, t2 ConnectionTarget) bool {
+	if t1.EnvId != nil && t2.EnvId != nil {
+		return *t1.EnvId == *t2.EnvId
+	}
+	return t1.EnvName == t2.EnvName
 }

--- a/types/connection_target_test.go
+++ b/types/connection_target_test.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConnection_TargetEquals(t *testing.T) {
+	ptr := func(id int64) *int64 {
+		return &id
+	}
+
+	tests := map[string]struct {
+		a    *ConnectionTarget
+		b    *ConnectionTarget
+		want bool
+	}{
+		"a stack-id does not equal b stack-id": {
+			a:    &ConnectionTarget{StackId: 1, BlockName: "block"},
+			b:    &ConnectionTarget{StackId: 2, BlockName: "block"},
+			want: false,
+		},
+		"a env-id does not equal b env-id": {
+			a:    &ConnectionTarget{BlockName: "block", EnvId: ptr(1)},
+			b:    &ConnectionTarget{BlockName: "block", EnvId: ptr(2)},
+			want: false,
+		},
+		"a missing env-id equals b on env-name": {
+			a:    &ConnectionTarget{BlockName: "block", EnvId: nil, EnvName: "dev"},
+			b:    &ConnectionTarget{BlockName: "block", EnvId: ptr(2), EnvName: "dev"},
+			want: true,
+		},
+		"a does not equal missing b": {
+			a:    &ConnectionTarget{BlockId: 10, BlockName: "block"},
+			b:    nil,
+			want: false,
+		},
+		"missing a does not equal b": {
+			a:    nil,
+			b:    &ConnectionTarget{BlockId: 10, BlockName: "block"},
+			want: false,
+		},
+		"a equals b": {
+			a:    &ConnectionTarget{StackId: 1, StackName: "core", BlockId: 10, BlockName: "block", EnvId: ptr(110), EnvName: "dev"},
+			b:    &ConnectionTarget{StackId: 1, StackName: "core", BlockId: 10, BlockName: "block", EnvId: ptr(110), EnvName: "dev"},
+			want: true,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := (&Connection{Reference: test.a}).TargetEquals(Connection{Reference: test.b})
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/types/variable.go
+++ b/types/variable.go
@@ -64,7 +64,15 @@ func (v *Variable) SchemaEquals(other Variable) bool {
 }
 
 func (v *Variable) ValueEquals(other Variable) bool {
-	return isVariableValueEqual(v.Type, v.Value, other.Value)
+	val1 := v.Value
+	if val1 == nil {
+		val1 = v.Default
+	}
+	val2 := other.Value
+	if val2 == nil {
+		val2 = other.Default
+	}
+	return isVariableValueEqual(v.Type, val1, val2)
 }
 
 type VariableInput struct {

--- a/types/variable_test.go
+++ b/types/variable_test.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"github.com/nullstone-io/module/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestVariable_ValueEquals(t *testing.T) {
+	varDef := config.Variable{
+		Type:        "number",
+		Description: "",
+		Default:     256,
+		Sensitive:   false,
+	}
+	tests := map[string]struct {
+		a    Variable
+		b    Variable
+		want bool
+	}{
+		"a value does not equal b value": {
+			a:    Variable{Variable: varDef, Value: 512},
+			b:    Variable{Variable: varDef, Value: 1024},
+			want: false,
+		},
+		"a default equals b value": {
+			a:    Variable{Variable: varDef, Value: nil},
+			b:    Variable{Variable: varDef, Value: 256},
+			want: true,
+		},
+		"a default equals b default": {
+			a:    Variable{Variable: varDef, Value: nil},
+			b:    Variable{Variable: varDef, Value: nil},
+			want: true,
+		},
+		"a value equals b default": {
+			a:    Variable{Variable: varDef, Value: 256},
+			b:    Variable{Variable: varDef, Value: nil},
+			want: true,
+		},
+		"a value equals b value": {
+			a:    Variable{Variable: varDef, Value: 512},
+			b:    Variable{Variable: varDef, Value: 512},
+			want: true,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := test.a.ValueEquals(test.b)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This fixes 2 issues with "over-diffing".
1. When diffing variables values, this will fall back to the variable default if the value is nil.
2. When diffing connection targets, this compare envs by id. If either is nil, it will compare by env name.