### PR TITLE
F/1995/remote creds

### DIFF
--- a/client.go
+++ b/client.go
@@ -121,6 +121,9 @@ func (c *Client) WorkspaceConfigFiles() WorkspaceConfigFiles {
 func (c *Client) WorkspaceOutputs() WorkspaceOutputs {
 	return WorkspaceOutputs{Client: c}
 }
+func (c *Client) WorkspaceOutputCredentials() WorkspaceOutputCredentials {
+	return WorkspaceOutputCredentials{Client: c}
+}
 func (c *Client) WorkspaceVariables() WorkspaceVariables {
 	return WorkspaceVariables{Client: c}
 }

--- a/types/output_credentials.go
+++ b/types/output_credentials.go
@@ -23,6 +23,9 @@ type OutputCredentials struct {
 	// Aws contains aws credentials
 	Aws *OutputCredentialsAws `json:"aws,omitempty"`
 
+	// Gcp contains gcp credentials
+	Gcp *OutputCredentialsGcp `json:"gcp,omitempty"`
+
 	// Data contains additional credential information
 	Data map[string]string `json:"data"`
 }
@@ -46,4 +49,21 @@ type OutputCredentialsAws struct {
 	// The time the credentials will expire at. Should be ignored if CanExpire
 	// is false.
 	Expires time.Time `json:"expires"`
+}
+
+type OutputCredentialsGcp struct {
+	// AccessToken is the token that authorizes and authenticates the requests.
+	AccessToken string `json:"accessToken"`
+
+	// TokenType is the type of token.
+	// The Type method returns either this or "Bearer", the default.
+	TokenType string `json:"tokenType"`
+
+	// RefreshToken is a token that's used by the application
+	// (as opposed to the user) to refresh the access token
+	// if it expires.
+	RefreshToken string `json:"refreshToken"`
+
+	// Expiry is the optional expiration time of the access token.
+	Expiry time.Time `json:"expiry,omitempty"`
 }

--- a/types/output_credentials.go
+++ b/types/output_credentials.go
@@ -1,0 +1,23 @@
+package types
+
+const (
+	ProviderAws   = "aws"
+	ProviderGcp   = "gcp"
+	ProviderAzure = "azure"
+)
+
+const (
+	CredentialsTypeAwsAssumeRole      = "aws-assume-role"
+	CredentialsTypeAwsGetSessionToken = "aws-get-session-token"
+)
+
+type OutputCredentials struct {
+	// Provider refers to the cloud provider (e.g. aws, gcp)
+	Provider string `json:"provider"`
+
+	// CredentialsType
+	CredentialsType string `json:"credentialsType"`
+
+	// Data contains the credentials information
+	Data map[string]string `json:"data"`
+}

--- a/types/output_credentials.go
+++ b/types/output_credentials.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 const (
 	ProviderAws   = "aws"
 	ProviderGcp   = "gcp"
@@ -18,6 +20,30 @@ type OutputCredentials struct {
 	// CredentialsType
 	CredentialsType string `json:"credentialsType"`
 
-	// Data contains the credentials information
+	// Aws contains aws credentials
+	Aws *OutputCredentialsAws `json:"aws,omitempty"`
+
+	// Data contains additional credential information
 	Data map[string]string `json:"data"`
+}
+
+type OutputCredentialsAws struct {
+	// AWS Access key ID
+	AccessKeyID string `json:"accessKeyID"`
+
+	// AWS Secret Access Key
+	SecretAccessKey string `json:"secretAccessKey"`
+
+	// AWS Session Token
+	SessionToken string `json:"sessionToken"`
+
+	// Source of the credentials
+	Source string `json:"source"`
+
+	// States if the credentials can expire or not.
+	CanExpire bool `json:"canExpire"`
+
+	// The time the credentials will expire at. Should be ignored if CanExpire
+	// is false.
+	Expires time.Time `json:"expires"`
 }

--- a/types/output_credentials.go
+++ b/types/output_credentials.go
@@ -65,5 +65,5 @@ type OutputCredentialsGcp struct {
 	RefreshToken string `json:"refreshToken"`
 
 	// Expiry is the optional expiration time of the access token.
-	Expiry time.Time `json:"expiry,omitempty"`
+	Expiry time.Time `json:"expiry"`
 }

--- a/workspace_output_credentials.go
+++ b/workspace_output_credentials.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"gopkg.in/nullstone-io/go-api-client.v0/response"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type WorkspaceOutputCredentials struct {
+	Client *Client
+}
+
+func (c WorkspaceOutputCredentials) path(stackId int64, workspaceUid uuid.UUID) string {
+	return fmt.Sprintf("orgs/%s/stacks/%d/workspaces/%s/output-credentials", c.Client.Config.OrgName, stackId, workspaceUid)
+}
+
+// Create - POST /orgs/:orgName/stacks/:stackId/workspaces/:workspaceUid/output-credentials
+func (c WorkspaceOutputCredentials) Create(ctx context.Context, stackId int64, workspaceUid uuid.UUID, outputNames []string) (*types.OutputCredentials, error) {
+	q := url.Values{}
+	q.Set("output_names", strings.Join(outputNames, ","))
+	res, err := c.Client.Do(ctx, http.MethodPost, c.path(stackId, workspaceUid), q, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.ReadJsonPtr[types.OutputCredentials](res)
+}

--- a/workspace_output_credentials.go
+++ b/workspace_output_credentials.go
@@ -20,8 +20,9 @@ func (c WorkspaceOutputCredentials) path(stackId int64, workspaceUid uuid.UUID) 
 }
 
 // Create - POST /orgs/:orgName/stacks/:stackId/workspaces/:workspaceUid/output-credentials
-func (c WorkspaceOutputCredentials) Create(ctx context.Context, stackId int64, workspaceUid uuid.UUID, outputNames []string) (*types.OutputCredentials, error) {
+func (c WorkspaceOutputCredentials) Create(ctx context.Context, stackId int64, workspaceUid uuid.UUID, provider string, outputNames []string) (*types.OutputCredentials, error) {
 	q := url.Values{}
+	q.Set("provider", provider)
 	q.Set("output_names", strings.Join(outputNames, ","))
 	res, err := c.Client.Do(ctx, http.MethodPost, c.path(stackId, workspaceUid), q, nil, nil)
 	if err != nil {


### PR DESCRIPTION
This adds an API endpoint and type to allow users with `software_engineer` role to fetch temporary credentials.