### PR TITLE
Added desired and effective values for connections and module version

### DIFF
--- a/types/capability_config.go
+++ b/types/capability_config.go
@@ -6,9 +6,18 @@ import (
 )
 
 type CapabilityConfig struct {
-	Id             int64       `json:"id"`
-	Name           string      `json:"name"`
-	Source         string      `json:"source"`
+	// Id is a unique identifier for all Capability objects
+	Id int64 `json:"id"`
+	// Name is a unique identifier for the Capability
+	// This is for all capabilities on a single Nullstone Application
+	Name string `json:"name"`
+	// Source refers to the module used for this workspace
+	Source string `json:"source"`
+	// SourceConstraint is a constraint or desired version for the workspace module
+	// Once resolved, SourceVersion contains the effective module version
+	SourceConstraint string `json:"sourceConstraint"`
+	// SourceVersion refers to the effective module version
+	// Variables and Connections on this WorkspaceConfig should match the schema for this module version
 	SourceVersion  string      `json:"sourceVersion"`
 	Variables      Variables   `json:"variables"`
 	Connections    Connections `json:"connections"`

--- a/types/connection.go
+++ b/types/connection.go
@@ -9,7 +9,7 @@ type Connection struct {
 
 	// Target refers to the ConnectionTarget that fulfills this connection
 	// This value is input by the user via UI or IaC and is not normalized
-	Target *ConnectionTarget `json:"target"`
+	Target *ConnectionTargetString `json:"target"`
 
 	// EffectiveTarget refers to the ConnectionTarget that fulfills this connection
 	// This value is a fully normalized, effective version of Target
@@ -29,7 +29,7 @@ type Connection struct {
 func (c *Connection) Equal(other Connection) bool {
 	return c.SchemaEquals(other) &&
 		c.Unused == other.Unused &&
-		isConnectionTargetEqual(c.Target, other.Target) &&
+		isConnectionTargetEqual(c.target(), other.target()) &&
 		isConnectionTargetEqual(c.EffectiveTarget, other.EffectiveTarget)
 }
 
@@ -45,6 +45,13 @@ func (c *Connection) SchemaEquals(other Connection) bool {
 }
 
 func (c *Connection) TargetEquals(other Connection) bool {
-	return isConnectionTargetEqual(c.Target, other.Target) &&
+	return isConnectionTargetEqual(c.target(), other.target()) &&
 		isConnectionTargetEqual(c.EffectiveTarget, other.EffectiveTarget)
+}
+
+func (c *Connection) target() *ConnectionTarget {
+	if c.Target == nil {
+		return nil
+	}
+	return &c.Target.ConnectionTarget
 }

--- a/types/connection_target.go
+++ b/types/connection_target.go
@@ -1,9 +1,5 @@
 package types
 
-import (
-	"strings"
-)
-
 type ConnectionTargets map[string]ConnectionTarget
 
 type ConnectionTarget struct {
@@ -13,29 +9,6 @@ type ConnectionTarget struct {
 	BlockName string `json:"blockName,omitempty" yaml:"block_name,omitempty"`
 	EnvId     *int64 `json:"envId,omitempty" yaml:"env_id,omitempty"`
 	EnvName   string `json:"envName,omitempty" yaml:"env_name,omitempty"`
-}
-
-func ParseConnectionTarget(s string) ConnectionTarget {
-	tokens := strings.Split(s, ".")
-	switch len(tokens) {
-	case 1:
-		return ConnectionTarget{
-			BlockName: tokens[0],
-		}
-	case 2:
-		return ConnectionTarget{
-			StackName: tokens[0],
-			BlockName: tokens[1],
-		}
-	case 3:
-		return ConnectionTarget{
-			StackName: tokens[0],
-			EnvName:   tokens[1],
-			BlockName: tokens[2],
-		}
-	default:
-		return ConnectionTarget{}
-	}
 }
 
 // Normalize

--- a/types/connection_target_string.go
+++ b/types/connection_target_string.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+var (
+	_ json.Unmarshaler = &ConnectionTargetString{}
+	_ json.Marshaler   = &ConnectionTargetString{}
+)
+
+// ConnectionTargetString is represented as a ConnectionTarget in memory, but serialized to JSON as a string value
+// IDs are ignored from the serialization; only StackName, EnvName, and BlockName are serialized
+// Valid Formats:
+// - `<block-name>`
+// - `<stack-name>.<block-name>`
+// - `<stack-name>.<env-name>.<block-name>`
+type ConnectionTargetString struct {
+	ConnectionTarget `json:",inline"`
+}
+
+// UnmarshalJSON is used to customize the parsing of an existing connection target
+// Deprecated: This is temporary as we transition Connection.Target from a string to a ConnectionTarget
+func (t *ConnectionTargetString) UnmarshalJSON(data []byte) error {
+	if data == nil {
+		return nil
+	}
+	var tmp struct {
+		StackId   int64  `json:"stackId"`
+		StackName string `json:"stackName"`
+		BlockId   int64  `json:"blockId"`
+		BlockName string `json:"blockName"`
+		EnvId     *int64 `json:"envId"`
+		EnvName   string `json:"envName"`
+	}
+	if err := json.Unmarshal(data, &tmp); err == nil {
+		t.StackId = tmp.StackId
+		t.StackName = tmp.StackName
+		t.BlockId = tmp.StackId
+		t.BlockName = tmp.BlockName
+		t.EnvId = tmp.EnvId
+		t.EnvName = tmp.EnvName
+		return nil
+	}
+	// It must be a legacy string, we're going to parse the format: `[[stack.]env.]block`
+	tokens := strings.Split(string(data), ".")
+	switch len(tokens) {
+	case 3:
+		t.StackName = tokens[0]
+		t.EnvName = tokens[1]
+		t.BlockName = tokens[2]
+	case 2:
+		t.StackName = tokens[0]
+		t.BlockName = tokens[1]
+	case 1:
+		t.BlockName = tokens[0]
+	}
+	return nil
+}
+
+func (t *ConnectionTargetString) MarshalJSON() ([]byte, error) {
+	if t == nil {
+		return nil, nil
+	}
+
+	tokens := make([]string, 0)
+	if t.StackName != "" {
+		tokens = append(tokens, t.StackName)
+	}
+	if t.EnvName != "" {
+		tokens = append(tokens, t.EnvName)
+	}
+	if t.BlockName != "" {
+		tokens = append(tokens, t.BlockName)
+	}
+	if len(tokens) > 0 {
+		return json.Marshal(strings.Join(tokens, "."))
+	}
+	return json.Marshal("")
+}

--- a/types/connection_target_test.go
+++ b/types/connection_target_test.go
@@ -49,7 +49,9 @@ func TestConnection_TargetEquals(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			got := (&Connection{Reference: test.a}).TargetEquals(Connection{Reference: test.b})
+			aconn := &Connection{EffectiveTarget: test.a}
+			bconn := &Connection{EffectiveTarget: test.b}
+			got := aconn.TargetEquals(*bconn)
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/types/connections.go
+++ b/types/connections.go
@@ -26,7 +26,11 @@ func (s Connections) EffectiveTargets() ConnectionTargets {
 func (s Connections) String() string {
 	result := make([]string, 0)
 	for name, c := range s {
-		result = append(result, fmt.Sprintf("%s=%s", name, c.EffectiveTarget.Workspace().Id()))
+		id := "(none)"
+		if c.EffectiveTarget != nil {
+			id = c.EffectiveTarget.Workspace().Id()
+		}
+		result = append(result, fmt.Sprintf("%s=%s", name, id))
 	}
 	return strings.Join(result, ",")
 }

--- a/types/connections.go
+++ b/types/connections.go
@@ -11,11 +11,11 @@ var (
 
 type Connections map[string]Connection
 
-func (s Connections) Targets() ConnectionTargets {
+func (s Connections) EffectiveTargets() ConnectionTargets {
 	result := ConnectionTargets{}
 	for k, c := range s {
-		if c.Reference != nil {
-			result[k] = *c.Reference
+		if c.EffectiveTarget != nil {
+			result[k] = *c.EffectiveTarget
 		} else {
 			result[k] = ConnectionTarget{}
 		}
@@ -26,7 +26,7 @@ func (s Connections) Targets() ConnectionTargets {
 func (s Connections) String() string {
 	result := make([]string, 0)
 	for name, c := range s {
-		result = append(result, fmt.Sprintf("%s=%s", name, c.Reference.Workspace().Id()))
+		result = append(result, fmt.Sprintf("%s=%s", name, c.EffectiveTarget.Workspace().Id()))
 	}
 	return strings.Join(result, ",")
 }


### PR DESCRIPTION
Updated `WorkspaceConfig` to contain desired and effective values.

- Added `SourceConstraint` to `WorkspaceConfig` and `CapabilityConfig`
- Transitioned `Connection.Target` to `ConnectionTarget` -- this refers to the user's desired workspace
- Added `Connection.EffectiveTarget` which contains the resolved reference to the workspace
- Added deprecation to `Connection.Reference` (Renamed to `OldReference` in code, but maintained the `reference` json tag)