### PR TITLE
Add ability to return capabilities in blocks#index

### DIFF
--- a/block_syncs.go
+++ b/block_syncs.go
@@ -14,8 +14,9 @@ type BlockSyncs struct {
 }
 
 type BlockSyncPayload struct {
-	Blocks   []types.Block `json:"blocks"`
-	RepoName string        `json:"repoName"`
+	Blocks           []types.Block `json:"blocks"`
+	RepoName         string        `json:"repoName"`
+	SkipCapabilities bool          `json:"skipCapabilities"`
 }
 
 func (s BlockSyncs) basePath(stackId, envId int64) string {

--- a/blocks.go
+++ b/blocks.go
@@ -24,19 +24,17 @@ func (s Blocks) blockPath(stackId, blockId int64) string {
 }
 
 // List - GET /orgs/:orgName/stacks/:stack_id/blocks
-func (s Blocks) List(ctx context.Context, stackId int64) ([]types.Block, error) {
-	res, err := s.Client.Do(ctx, http.MethodGet, s.basePath(stackId), nil, nil, nil)
+func (s Blocks) List(ctx context.Context, stackId int64, includeCapabilities bool) ([]types.Block, error) {
+	var q url.Values
+	if includeCapabilities {
+		q = url.Values{"include_capabilities": []string{"true"}}
+	}
+	res, err := s.Client.Do(ctx, http.MethodGet, s.basePath(stackId), q, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var blocks []types.Block
-	if err := response.ReadJson(res, &blocks); response.IsNotFoundError(err) {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	}
-	return blocks, nil
+	return response.ReadJsonVal[[]types.Block](res)
 }
 
 // Get - GET /orgs/:orgName/stacks/:stack_id/blocks/:id

--- a/find/stack_and_block_by_name.go
+++ b/find/stack_and_block_by_name.go
@@ -22,7 +22,7 @@ func blockByStackAndBlockName(ctx context.Context, cfg api.Config, stackName, bl
 	} else if stack == nil {
 		return nil, nil, nil
 	}
-	blocks, err := client.Blocks().List(ctx, stack.Id)
+	blocks, err := client.Blocks().List(ctx, stack.Id, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,7 +46,7 @@ func blockByBlockNameNoStack(ctx context.Context, cfg api.Config, blockName stri
 	foundStackNames := make([]string, 0)
 	for _, stack := range stacks {
 		stacksById[stack.Id] = stack
-		blocks, err := client.Blocks().List(ctx, stack.Id)
+		blocks, err := client.Blocks().List(ctx, stack.Id, false)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error retrieving blocks in stack (%s): %w", stack.Name, err)
 		}

--- a/find/stack_resolver.go
+++ b/find/stack_resolver.go
@@ -148,7 +148,7 @@ func (r *StackResolver) ensureBlocks(ctx context.Context) error {
 }
 
 func (r *StackResolver) LoadBlocks(ctx context.Context) error {
-	blocks, err := r.ApiClient.Blocks().List(ctx, r.Stack.Id)
+	blocks, err := r.ApiClient.Blocks().List(ctx, r.Stack.Id, false)
 	if err != nil {
 		return fmt.Errorf("unable to fetch blocks (%s/%d): %w", r.Stack.OrgName, r.Stack.Id, err)
 	}


### PR DESCRIPTION
This adds a querystring param `include_capabilities=true` to the API client when listing blocks.