### PR TITLE
F/102/env specific connections

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -16,20 +16,19 @@ const (
 
 type Block struct {
 	IdModel
-	Type                string                      `json:"type"`
-	OrgName             string                      `json:"orgName"`
-	StackId             int64                       `json:"stackId"`
-	Reference           string                      `json:"reference"`
-	Name                string                      `json:"name"`
-	IsShared            bool                        `json:"isShared"`
-	OwningRepo          string                      `json:"owningRepo"`
-	Repo                string                      `json:"repo,omitempty"`
-	RepoUrl             string                      `json:"repoUrl,omitempty"`
-	Framework           string                      `json:"framework,omitempty"`
-	DnsName             string                      `json:"dnsName,omitempty"`
-	ModuleSource        string                      `json:"moduleSource"`
-	ModuleSourceVersion string                      `json:"moduleSourceVersion"`
-	Connections         map[string]ConnectionTarget `json:"connections"`
+	Type                string `json:"type"`
+	OrgName             string `json:"orgName"`
+	StackId             int64  `json:"stackId"`
+	Reference           string `json:"reference"`
+	Name                string `json:"name"`
+	IsShared            bool   `json:"isShared"`
+	OwningRepo          string `json:"owningRepo"`
+	Repo                string `json:"repo,omitempty"`
+	RepoUrl             string `json:"repoUrl,omitempty"`
+	Framework           string `json:"framework,omitempty"`
+	DnsName             string `json:"dnsName,omitempty"`
+	ModuleSource        string `json:"moduleSource"`
+	ModuleSourceVersion string `json:"moduleSourceVersion"`
 }
 
 type Blocks []Block

--- a/types/block.go
+++ b/types/block.go
@@ -27,6 +27,16 @@ type Block struct {
 	RepoUrl    string `json:"repoUrl,omitempty"`
 	Framework  string `json:"framework,omitempty"`
 	DnsName    string `json:"dnsName,omitempty"`
+
+	// ModuleSource
+	// Deprecated - This has been moved to WorkspaceConfig
+	ModuleSource string `json:"moduleSource"`
+	// ModuleSourceVersion
+	// Deprecated - This has been moved to WorkspaceConfig
+	ModuleSourceVersion string `json:"moduleSourceVersion"`
+	// Connections
+	// Deprecated - This has been moved to WorkspaceConfig
+	Connections map[string]ConnectionTarget `json:"connections"`
 }
 
 type Blocks []Block

--- a/types/block.go
+++ b/types/block.go
@@ -16,19 +16,17 @@ const (
 
 type Block struct {
 	IdModel
-	Type                string `json:"type"`
-	OrgName             string `json:"orgName"`
-	StackId             int64  `json:"stackId"`
-	Reference           string `json:"reference"`
-	Name                string `json:"name"`
-	IsShared            bool   `json:"isShared"`
-	OwningRepo          string `json:"owningRepo"`
-	Repo                string `json:"repo,omitempty"`
-	RepoUrl             string `json:"repoUrl,omitempty"`
-	Framework           string `json:"framework,omitempty"`
-	DnsName             string `json:"dnsName,omitempty"`
-	ModuleSource        string `json:"moduleSource"`
-	ModuleSourceVersion string `json:"moduleSourceVersion"`
+	Type       string `json:"type"`
+	OrgName    string `json:"orgName"`
+	StackId    int64  `json:"stackId"`
+	Reference  string `json:"reference"`
+	Name       string `json:"name"`
+	IsShared   bool   `json:"isShared"`
+	OwningRepo string `json:"owningRepo"`
+	Repo       string `json:"repo,omitempty"`
+	RepoUrl    string `json:"repoUrl,omitempty"`
+	Framework  string `json:"framework,omitempty"`
+	DnsName    string `json:"dnsName,omitempty"`
 }
 
 type Blocks []Block

--- a/workspace_configs.go
+++ b/workspace_configs.go
@@ -3,9 +3,10 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"gopkg.in/nullstone-io/go-api-client.v0/response"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
-	"net/http"
 )
 
 type WorkspaceConfigs struct {
@@ -16,11 +17,16 @@ func (w WorkspaceConfigs) currentPath(stackId, blockId, envId int64) string {
 	return fmt.Sprintf("orgs/%s/stacks/%d/blocks/%d/envs/%d/configs/current", w.Client.Config.OrgName, stackId, blockId, envId)
 }
 
+func (w WorkspaceConfigs) latestPath(stackId, blockId, envId int64) string {
+	return fmt.Sprintf("orgs/%s/stacks/%d/blocks/%d/envs/%d/configs/latest", w.Client.Config.OrgName, stackId, blockId, envId)
+}
+
 func (w WorkspaceConfigs) effectivePath(stackId, blockId, envId int64) string {
 	return fmt.Sprintf("orgs/%s/stacks/%d/blocks/%d/envs/%d/configs/effective", w.Client.Config.OrgName, stackId, blockId, envId)
 }
 
 // GetCurrent - GET /orgs/:orgName/stacks/:stackId/blocks/:blockId/envs/:envId/configs/current
+// Current represents the workspace config from the last finished run
 func (w WorkspaceConfigs) GetCurrent(ctx context.Context, stackId, blockId, envId int64) (*types.WorkspaceConfig, error) {
 	res, err := w.Client.Do(ctx, http.MethodGet, w.currentPath(stackId, blockId, envId), nil, nil, nil)
 	if err != nil {
@@ -30,7 +36,18 @@ func (w WorkspaceConfigs) GetCurrent(ctx context.Context, stackId, blockId, envI
 	return response.ReadJsonPtr[types.WorkspaceConfig](res)
 }
 
+// GetLatest - GET /orgs/:orgName/stacks/:stackId/blocks/:blockId/envs/:envId/configs/latest
+// Latest represents the latest workspace config
+func (w WorkspaceConfigs) GetLatest(ctx context.Context, stackId, blockId, envId int64) (*types.WorkspaceConfig, error) {
+	res, err := w.Client.Do(ctx, http.MethodGet, w.latestPath(stackId, blockId, envId), nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return response.ReadJsonPtr[types.WorkspaceConfig](res)
+}
+
 // GetEffective - GET /orgs/:orgName/stacks/:stackId/blocks/:blockId/envs/:envId/configs/effective
+// Effective represents the latest workspace config with unapplied changes
 func (w WorkspaceConfigs) GetEffective(ctx context.Context, stackId, blockId, envId int64) (*types.WorkspaceConfig, error) {
 	res, err := w.Client.Do(ctx, http.MethodGet, w.currentPath(stackId, blockId, envId), nil, nil, nil)
 	if err != nil {


### PR DESCRIPTION
This upgrades the client types to support env-specific module and connections for a Block.
The following Block fields were deprecated:
- `ModuleSource`
- `ModuleSourceVersion`
- `Connections`

An additional API endpoint was added, `WorkspaceConfigs.GetLatest`.