### PR TITLE
F/102/env specific capabilities

### DIFF
--- a/types/capability.go
+++ b/types/capability.go
@@ -11,4 +11,5 @@ type Capability struct {
 	Connections         map[string]ConnectionTarget `json:"connections,omitempty"`
 	Namespace           string                      `json:"namespace"`
 	Status              string                      `json:"status,omitempty"`
+	TfId                string                      `json:"tfId"`
 }

--- a/types/capability_config.go
+++ b/types/capability_config.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 type CapabilityConfig struct {
 	// Id is a unique identifier for all Capability objects
 	Id int64 `json:"id"`
@@ -23,18 +25,22 @@ type CapabilityConfig struct {
 	Namespace      string      `json:"namespace"`
 }
 
-func (s CapabilityConfig) ToTf() TfCapability {
+func (c CapabilityConfig) ToTf() TfCapability {
+	id := c.TfId
+	if id == "" {
+		id = fmt.Sprintf("%d", c.Id)
+	}
 	return TfCapability{
-		Id:               s.TfId,
-		TfId:             s.TfId,
-		Name:             s.Name,
-		Source:           s.Source,
-		SourceConstraint: s.SourceConstraint,
-		SourceVersion:    s.SourceVersion,
-		Variables:        s.Variables,
-		Connections:      s.Connections,
-		NeedsDestroyed:   s.NeedsDestroyed,
-		Namespace:        s.Namespace,
+		Id:               id,
+		TfId:             id,
+		Name:             c.Name,
+		Source:           c.Source,
+		SourceConstraint: c.SourceConstraint,
+		SourceVersion:    c.SourceVersion,
+		Variables:        c.Variables,
+		Connections:      c.Connections,
+		NeedsDestroyed:   c.NeedsDestroyed,
+		Namespace:        c.Namespace,
 	}
 }
 

--- a/types/capability_config.go
+++ b/types/capability_config.go
@@ -1,10 +1,5 @@
 package types
 
-import (
-	"fmt"
-	"strings"
-)
-
 type CapabilityConfig struct {
 	// Id is a unique identifier for all Capability objects
 	Id int64 `json:"id"`
@@ -28,19 +23,19 @@ type CapabilityConfig struct {
 	Namespace      string      `json:"namespace"`
 }
 
-func (c CapabilityConfig) TfModuleAddr() string {
-	return fmt.Sprintf("module.cap_%s", c.TfId)
-}
-
-func (c CapabilityConfig) TfModuleName() string {
-	return fmt.Sprintf("cap_%s", c.TfId)
-}
-
-func (c CapabilityConfig) EnvPrefix() string {
-	if c.Namespace == "" {
-		return ""
+func (s CapabilityConfig) ToTf() TfCapability {
+	return TfCapability{
+		Id:               s.TfId,
+		TfId:             s.TfId,
+		Name:             s.Name,
+		Source:           s.Source,
+		SourceConstraint: s.SourceConstraint,
+		SourceVersion:    s.SourceVersion,
+		Variables:        s.Variables,
+		Connections:      s.Connections,
+		NeedsDestroyed:   s.NeedsDestroyed,
+		Namespace:        s.Namespace,
 	}
-	return fmt.Sprintf("%s_", strings.ToUpper(c.Namespace))
 }
 
 func (c CapabilityConfig) Equal(b CapabilityConfig) bool {

--- a/types/capability_config.go
+++ b/types/capability_config.go
@@ -8,6 +8,9 @@ import (
 type CapabilityConfig struct {
 	// Id is a unique identifier for all Capability objects
 	Id int64 `json:"id"`
+	// TfId is a unique identifier used for creating unique Terraform resources
+	// It is unique among all capabilities in the Application Workspace
+	TfId string `json:"tfId"`
 	// Name is a unique identifier for the Capability
 	// This is for all capabilities on a single Nullstone Application
 	Name string `json:"name"`
@@ -26,11 +29,11 @@ type CapabilityConfig struct {
 }
 
 func (c CapabilityConfig) TfModuleAddr() string {
-	return fmt.Sprintf("module.cap_%d", c.Id)
+	return fmt.Sprintf("module.cap_%s", c.TfId)
 }
 
 func (c CapabilityConfig) TfModuleName() string {
-	return fmt.Sprintf("cap_%d", c.Id)
+	return fmt.Sprintf("cap_%s", c.TfId)
 }
 
 func (c CapabilityConfig) EnvPrefix() string {

--- a/types/capability_configs.go
+++ b/types/capability_configs.go
@@ -14,20 +14,10 @@ func (s CapabilityConfigs) FindById(id int64) *CapabilityConfig {
 	return nil
 }
 
-func (s CapabilityConfigs) ExceptNeedsDestroyed() CapabilityConfigs {
-	result := make(CapabilityConfigs, 0)
+func (s CapabilityConfigs) ToTf() TfCapabilities {
+	result := make(TfCapabilities, 0)
 	for _, cur := range s {
-		if !cur.NeedsDestroyed {
-			result = append(result, cur)
-		}
-	}
-	return result
-}
-
-func (s CapabilityConfigs) TfModuleAddrs() []string {
-	result := make([]string, 0)
-	for _, cur := range s {
-		result = append(result, cur.TfModuleAddr())
+		result = append(result, cur.ToTf())
 	}
 	return result
 }

--- a/types/tf_capabilities.go
+++ b/types/tf_capabilities.go
@@ -1,0 +1,21 @@
+package types
+
+type TfCapabilities []TfCapability
+
+func (s TfCapabilities) ExceptNeedsDestroyed() TfCapabilities {
+	result := make(TfCapabilities, 0)
+	for _, cur := range s {
+		if !cur.NeedsDestroyed {
+			result = append(result, cur)
+		}
+	}
+	return result
+}
+
+func (s TfCapabilities) TfModuleAddrs() []string {
+	result := make([]string, 0)
+	for _, cur := range s {
+		result = append(result, cur.TfModuleAddr())
+	}
+	return result
+}

--- a/types/tf_capability.go
+++ b/types/tf_capability.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TfCapability is a copy of the types.CapabilityConfig; however, the Id attribute is a string and uses the TfId backing attribute
+// This allows us to upgrade the capability without forcing every Terraform module to upgrade to use TfId
+type TfCapability struct {
+	// Id represents the old attribute used for Terraform resource identification
+	// Deprecated - This will be dropped when all Terraform modules use TfId
+	Id string `json:"id"`
+	// TfId is the new attribute used for Terraform resource identification
+	TfId             string      `json:"tfId"`
+	Name             string      `json:"name"`
+	Source           string      `json:"source"`
+	SourceConstraint string      `json:"sourceConstraint"`
+	SourceVersion    string      `json:"sourceVersion"`
+	Variables        Variables   `json:"variables"`
+	Connections      Connections `json:"connections"`
+	NeedsDestroyed   bool        `json:"needsDestroyed"`
+	Namespace        string      `json:"namespace"`
+}
+
+func (c TfCapability) TfModuleAddr() string {
+	return fmt.Sprintf("module.cap_%s", c.TfId)
+}
+
+func (c TfCapability) TfModuleName() string {
+	return fmt.Sprintf("cap_%s", c.TfId)
+}
+
+func (c TfCapability) EnvPrefix() string {
+	if c.Namespace == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s_", strings.ToUpper(c.Namespace))
+}


### PR DESCRIPTION
This adds TfCapabilities and TfCapability to use for terraform capability template generation.
This uses the `TfId` attribute from upgraded capabilities which falls back to `Id`.
This enables support for env-specific workspaces.